### PR TITLE
Align data model/dictionary descriptions and examples with new naming standards

### DIFF
--- a/docs/datamodels.md
+++ b/docs/datamodels.md
@@ -1,4 +1,4 @@
-# Neurobagel Datamodels
+# Neurobagel Data Models
 
 ## Data Dictionaries
 
@@ -45,11 +45,11 @@ And here is the same example with Neurobagel annotations added:
     "Units": "years",
     "Annotations": {
       "IsAbout": {
-        "TermURL": "http://purl.obolibrary.org/obo/NCIT_C25150",
+        "TermURL": "http://neurobagel.org/vocab/Age",
         "Label": "Age"
       },
-      "Unit": {
-        "TermURL": "xsd:integer",
+      "Transformation": {
+        "TermURL": "http://neurobagel.org/vocab/int",
         "Label": "Integer"
       }
     }
@@ -62,16 +62,16 @@ And here is the same example with Neurobagel annotations added:
     },
     "Annotations": {
       "IsAbout": {
-        "TermURL": "http://purl.obolibrary.org/obo/NCIT_C28421",
+        "TermURL": "http://neurobagel.org/vocab/Sex",
         "Label": "Sex"
       },
       "Levels": {
         "M": {
-          "TermURL": "http://purl.obolibrary.org/obo/NCIT_C20197",
+          "TermURL": "http://purl.bioontology.org/ontology/SNOMEDCT/248153007",
           "Label": "Male"
         },
         "F": {
-          "TermURL": "http://purl.obolibrary.org/obo/NCIT_C16576",
+          "TermURL": "http://purl.bioontology.org/ontology/SNOMEDCT/248152002",
           "Label": "Female"
         }
       },
@@ -84,5 +84,9 @@ And here is the same example with Neurobagel annotations added:
 }
 ```
 
-### Special attributes
+Note that we use a Neurobagel namespace (URI: http://neurobagel.org/vocab/) for controlled terms representing classes or properties that we model, such as `"Age"` and `"Sex"`, but that these can have equivalent terms in another namespace we are using. For example, the following terms from the Neurobagel annotations above are conceptually equivalent to terms from the SNOMED-CT namespace:
 
+| Neurobagel namespace term       | External controlled vocabulary term                     |
+|---------------------------------|---------------------------------------------------------|
+| http://neurobagel.org/vocab/Age | http://purl.bioontology.org/ontology/SNOMEDCT/397669002 |
+| http://neurobagel.org/vocab/Sex | http://purl.bioontology.org/ontology/SNOMEDCT/184100006 |

--- a/docs/dictionaries.md
+++ b/docs/dictionaries.md
@@ -1,8 +1,7 @@
 # Neurobagel Data Dictionaries
 
-The neurobagel annotator creates a BIDS compatible data dictionary
-and augments the information that BIDS recommends with 
-unambiguous semantic tags.
+The Neurobagel annotator creates a BIDS compatible data dictionary
+and augments the information that BIDS recommends with unambiguous semantic tags.
 
 Below we'll outline several special cases using the following example `participants.tsv` file:
 
@@ -19,24 +18,25 @@ syntax for [json-ld](https://w3c.github.io/json-ld-syntax/#the-context):
 ```json
 {
   "@context": {
-    "bg": "https://terms.neurobagel.org/",
+    "nb": "http://neurobagel.org/vocab/",
     "purl": "http://purl.obolibrary.org/obo/",
     "snomed": "http://purl.bioontology.org/ontology/SNOMEDCT/",
-    "cogAtlas": "https://www.cognitiveatlas.org/task/id/"
+    "cogatlas": "https://www.cognitiveatlas.org/task/id/"
   }
 }
 ```
 
 ## Participant identifier
 
-Term from National Cancer Institute Thesaurus
+Term from the Neurobagel vocabulary.
 
-```json hl_lines="5-6"
+```json hl_lines="6-7"
 {
   "participant_id": {
+    "Description": "A participant ID",
     "Annotations": {
       "IsAbout": {
-        "TermURL": "purl:NCIT_C69256",
+        "TermURL": "nb:ParticipantID",
         "Label": "Subject Unique Identifier"
       }
     }
@@ -53,14 +53,15 @@ Term from National Cancer Institute Thesaurus
 
 ## Session identifier
 
-Term from National Cancer Institute Thesaurus
+Term from the Neurobagel vocabulary.
 
-```json hl_lines="5-6"
+```json hl_lines="6-7"
 {
   "session_id": {
+    "Description": "A session ID",
     "Annotations": {
       "IsAbout": {
-        "TermURL": "purl:NCIT_C117058",
+        "TermURL": "nb:SessionID",
         "Label": "Run Identifier"
       }
     }
@@ -78,12 +79,17 @@ Term from National Cancer Institute Thesaurus
 Terms from the [SNOMED-CT ontology](https://browser.ihtsdotools.org/) for clinical diagnosis.
 Terms from the National Cancer Institute Thesaurus for healthy control status.
 
-```json hl_lines="5-6 10-11 14-15"
+```json hl_lines="10-11 15-16 19-20"
 {
   "group": {
+    "Description": "Group variable",
+    "Levels": {
+      "PD": "Parkinson's patient",
+      "CTRL": "Control subject",
+    },
     "Annotations": {
       "IsAbout": {
-        "TermURL": "bg:diagnosis",
+        "TermURL": "nb:Diagnosis",
         "Label": "Diagnosis"
       },
       "Levels": {
@@ -101,28 +107,33 @@ Terms from the National Cancer Institute Thesaurus for healthy control status.
 }
 ```
 
-The `IsAbout` relation uses a term from the neurobagel (`bg`) namespace because
+The `IsAbout` relation uses a term from the Neurobagel namespace because
 `"Diagnosis"` is a standardized term.
 
 ## Sex
 
-Terms are from the BIDS recommended namespace.
+Terms are from the SNOMED-CT ontology.
 
 ```json
 {
-    "sex": {
+  "sex": {
+    "Description": "Sex variable",
+    "Levels": {
+      "M": "Male",
+      "F": "Female"
+    },
     "Annotations": {
       "IsAbout": {
-        "TermURL": "bg:sex",
+        "TermURL": "nb:Sex",
         "Label": "Sex"
       },
       "Levels": {
         "M": {
-          "TermURL": "bids:male",
+          "TermURL": "snomed:248153007",
           "Label": "Male"
         },
         "F": {
-          "TermURL": "bids:female",
+          "TermURL": "snomed:248152002",
           "Label": "Female"
         }
       }
@@ -131,42 +142,69 @@ Terms are from the BIDS recommended namespace.
 }
 ```
 
-The `IsAbout` relation uses a Neurobagel (`bg`) scoped term for `sex` because 
+The `IsAbout` relation uses a Neurobagel scoped term for `"Sex"` because 
 this is a Neurobagel common data element.
+
+## Age
+Neurobagel has a common data element for `"Age"` which describes a continuous column. To ensure age values are represented as floats in Neurobagel graphs, Neurobagel encodes the relevant "heuristic" describing the value format of a given age column. This heuristic, stored in the `Transformation` annotation, corresponds internally to a specific transformation that is used to convert the values to float ages.
+
+Possible heuristics are: `float`, `int`, `euro`, `bounded`, `range`, `iso8601`
+
+```json hl_lines="9-12"
+{
+  "age": {
+    "Description": "Participant age",
+    "Annotations": {
+      "IsAbout": {
+        "TermURL": "nb:Age",
+        "Label": "Chronological age"
+      },
+      "Transformation": {
+        "TermURL": "nb:euro",
+        "Label": "European value decimals"
+      }
+    }
+  }
+}
+```
 
 ## Assessment tool
 
 For assessment tools like cognitive tests or rating scales, 
 Neurobagel encodes whether the tool was successfully completed.
 Because assessment tools often have several subscales or items 
-that can be stored in the tabular `participant.tsv` file,
-each assessment tool column gets two tags:
+that can be stored as separate columns in the tabular `participant.tsv` file,
+each assessment tool column gets at least two annotations:
 
 - one to classify it as `IsAbout` the generic category of assessment tools
 - one to classify it as `PartOf` the specific assessment tool
 
-```json hl_lines="4 8 24"
+An additional annotation `MissingValues` can be used to specify value(s) in an assessment tool column which represent that the participant is missing a value/response for that subscale, when instances of missing values are present.
+
+```json hl_lines="5 9 26"
 {
   "updrs_1": {
+    "Description": "item 1 scores for UPDRS",
     "Annotations": {
       "IsAbout": {
-        "TermURL": "bg:assessment",
+        "TermURL": "nb:Assessment",
         "Label": "Assessment tool"
       },
       "IsPartOf": {
-        "TermURL": "cogAtlas:tsk_4a57abb949ece",
+        "TermURL": "cogatlas:tsk_4a57abb949ece",
         "Label": "Unified Parkinson's Disease Rating Scale"
       }
     }
   },
   "updrs_2": {
+    "Description": "item 2 scores for UPDRS",
     "Annotations": {
       "IsAbout": {
-        "TermURL": "bg:assessment",
+        "TermURL": "nb:Assessment",
         "Label": "Assessment tool"
       },
       "IsPartOf": {
-        "TermURL": "cogAtlas:tsk_4a57abb949ece",
+        "TermURL": "cogatlas:tsk_4a57abb949ece",
         "Label": "Unified Parkinson's Disease Rating Scale"
       },
       "MissingValues": [""]
@@ -176,7 +214,7 @@ each assessment tool column gets two tags:
 ```
 
 To determine whether a specific assessment tool is available for a given participant,
-we then combine all of the columns that were classified as `PartOf` the specific tool
+we then combine all of the columns that were classified as `PartOf` that specific tool
 and then apply a simple `all()` heuristic to check that none of the columns
 contain any `MissingValues`.
 

--- a/docs/dictionaries.md
+++ b/docs/dictionaries.md
@@ -113,7 +113,7 @@ The `IsAbout` relation uses a term from the Neurobagel namespace because
 
 ## Sex
 
-Terms are from the SNOMED-CT ontology.
+Terms are from the SNOMED-CT ontology, which has controlled terms aligning with BIDS `participants.tsv` descriptions for sex.
 
 ```json
 {

--- a/docs/dictionaries.md
+++ b/docs/dictionaries.md
@@ -1,7 +1,8 @@
 # Neurobagel Data Dictionaries
 
 The Neurobagel annotator creates a BIDS compatible data dictionary
-and augments the information that BIDS recommends with unambiguous semantic tags.
+and augments the information that BIDS recommends with unambiguous 
+semantic tags.
 
 Below we'll outline several special cases using the following example `participants.tsv` file:
 

--- a/docs/dictionaries.md
+++ b/docs/dictionaries.md
@@ -1,8 +1,8 @@
 # Neurobagel Data Dictionaries
 
 The Neurobagel annotator creates a BIDS compatible data dictionary
-and augments the information that BIDS recommends with unambiguous 
-semantic tags.
+and augments the information that BIDS recommends with 
+unambiguous semantic tags.
 
 Below we'll outline several special cases using the following example `participants.tsv` file:
 

--- a/docs/term_naming_standards.md
+++ b/docs/term_naming_standards.md
@@ -1,0 +1,53 @@
+# Standards for controlled term naming
+
+## Naming conventions
+### Namespace prefixes
+- Names should be all lowercase (e.g., `nidm`, `cogatlas`)
+
+### Properties (graph "edges")
+- Names should adhere to camelCase (uses capitalized words except for the first word/letter)
+- Should be a compound of:
+    - a verb relevant to the property (e.g., **has**Age, **is**SubjectGroup)
+    - the [range](https://www.w3.org/TR/owl-ref/#range-def) of the property, (e.g.,has**Diagnosis** points to a Diagnosis object)
+
+What this might look like in semantic triples:
+```
+<Subject> <nb:hasDiagnosis> <snomed:1234>
+<snomed:1234> <rdf:type> <nb:Diagnosis>
+```
+
+### Classes or resources (graph "nodes")
+- Names should adhere to PascalCase (each word capitalized)
+- Where possible, simplify to a single word (e.g., `Diagnosis`, `Dataset`, `Sex`)
+
+!!! note
+
+    Generally, we own the terms for properties and classes (e.g., Diagnosis, Assessment) but not the resources representing _instances_ of classes such as specific diagnosis, sex, or assessment values (these are reused from existing vocabularies).
+
+    In cases where we reuse a term for a class that comes from an existing controlled vocabulary, and that vocabulary follows a different naming convention (e.g., all lowercase), we should follow the existing naming convention.
+
+## Currently used namespaces
+| Prefix     | IRI                                            | Types of terms                            |
+| ---------- | ---------------------------------------------- | ----------------------------------------- |
+| `nb`       | http://neurobagel.org/vocab/                   | Neurobagel-"owned" properties and classes |
+| `nbg`      | http://neurobagel.org/graph/                   | Neurobagel graph databases                |
+| `snomed`   | http://purl.bioontology.org/ontology/SNOMEDCT/ | diagnosis and sex values                  |
+| `nidm`     | http://purl.org/nidash/nidm#                   | imaging modalities                        |
+| `cogatlas` | https://www.cognitiveatlas.org/task/id/        | cognitive assessments and tasks           |
+
+
+## What if an `nb` term already exists in another controlled vocabulary?
+If there is an equivalent controlled term to one we are defining in a different namespace, 
+we document this and express their equivalence using `owl:sameAs`.
+
+Example:  
+If our term is `nb:Subject` and `nidm:Subject` is conceptually equivalent:
+```
+<nb:12345> a <nb:Subject>
+<nb:Subject> a <rdfs:Resource>;
+	<owl:sameAs> <nidm:Subject>
+```
+
+## Other general guidelines
+- Each property (edge) should use a single namespace for the resources it corresponds to
+- Where possible, hardcode or refer to identifiers and not human-readable labels


### PR DESCRIPTION
On the data dictionaries page, prefixes have been kept for now since the `@context` with URIs is shown as well.

Closes #5