### PR TITLE
[DOC] add term naming standards page to nav & update page title

### DIFF
--- a/docs/term_naming_standards.md
+++ b/docs/term_naming_standards.md
@@ -1,4 +1,4 @@
-# Standards for controlled term naming
+# Neurobagel standards for controlled term naming
 
 ## Naming conventions
 ### Namespace prefixes

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,7 +14,7 @@ nav:
   - Welcome: "index.md"
   - Data models: "datamodels.md"
   - Data dictionaries: "dictionaries.md"
-  - Controlled term naming: "term_naming_standards.md"
+  - Naming conventions for terms: "term_naming_standards.md"
   - MR Proc user guide: 
     - Overview: "mr_proc/overview.md"
     - Installation: "mr_proc/installation.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,8 +12,9 @@ repo_url: https://github.com/neurobagel/documentation
 # Page Navigation
 nav:
   - Welcome: "index.md"
-  - Data Models: "datamodels.md"
+  - Data models: "datamodels.md"
   - Data dictionaries: "dictionaries.md"
+  - Controlled term naming: "term_naming_standards.md"
   - MR Proc user guide: 
     - Overview: "mr_proc/overview.md"
     - Installation: "mr_proc/installation.md"


### PR DESCRIPTION
<!---
Until this PR is ready for review, you can include the [WIP] tag in its title, or leave it as a github draft.
-->






<!---
This is a suggested pull request template.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue
when this pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.

You can also just link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers
to indicate what they should be looking for when they review the pull request.
-->
Changes proposed in this pull request:

In https://github.com/neurobagel/documentation/pull/9 which added the controlled term naming standards page to encarta, I was silly and forgot to add the new page to the navigation in `mkdocs.yml`. This PR makes the page visible and also updates the page/nav titles slightly for consistency.

## Checklist

- [X] PR has an interpretable title with a prefix (`[ENH]`, `[BUG]`, `[DOC]`, `[INFRA]`, `[MAINT]`)
- [ ] PR links to Github issue with mention `Closes #XXXX`
- [ ] Tests pass
- [X] Code is properly formatted


For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
