### PR TITLE
Update data dictionaries page with comprehensive example link, missing values, terms for sex

### DIFF
--- a/docs/dictionaries.md
+++ b/docs/dictionaries.md
@@ -4,7 +4,7 @@ The Neurobagel annotator creates a BIDS compatible data dictionary
 and augments the information that BIDS recommends with 
 unambiguous semantic tags.
 
-Below we'll outline several special cases using the following example `participants.tsv` file:
+Below we'll outline several example annotations using the following example `participants.tsv` file:
 
 | participant_id | session_id | group | age | sex | updrs_1 | updrs_2 |
 |----------------|------------|-------|-----|-----|---------|---------|
@@ -26,6 +26,9 @@ syntax for [json-ld](https://w3c.github.io/json-ld-syntax/#the-context):
   }
 }
 ```
+
+!!! tip
+    A comprehensive example data dictionary containing all currently supported phenotypic attributes and annotations can be found [here](https://github.com/neurobagel/bagel-cli/blob/main/bagel/tests/data/example_synthetic.json) (corresponding [phenotypic .tsv](https://github.com/neurobagel/bagel-cli/blob/main/bagel/tests/data/example_synthetic.tsv)).
 
 ## Participant identifier
 

--- a/docs/dictionaries.md
+++ b/docs/dictionaries.md
@@ -191,7 +191,7 @@ each assessment tool column gets at least two annotations:
 - one to classify it as `IsAbout` the generic category of assessment tools
 - one to classify it as `PartOf` the specific assessment tool
 
-An additional annotation `MissingValues` can be used to specify value(s) in an assessment tool column which represent that the participant is missing a value/response for that subscale, when instances of missing values are present.
+An additional annotation `MissingValues` can be used to specify value(s) in an assessment tool column which represent that the participant is missing a value/response for that subscale, when instances of missing values are present (see also section [Missing values](#missing-values)).
 
 ```json hl_lines="5 9 26"
 {
@@ -244,3 +244,7 @@ Therefore:
 | sub-01        | False           |
 | sub-02        | True            |
 
+## Missing values
+Missing values are allowed for any phenotypic variable (column) that does not describe a participant or session identifier (e.g., columns like `participant_id` or `session_id`). 
+In a Neurobagel data dictionary, missing values for a given column are listed under the `"MissingValues"` annotation for the column (see the [Assessment tool](#assessment-tool) section
+or the [comprehensive example data dictionary](https://github.com/neurobagel/bagel-cli/blob/main/bagel/tests/data/example_synthetic.json) for examples).

--- a/docs/dictionaries.md
+++ b/docs/dictionaries.md
@@ -116,7 +116,15 @@ The `IsAbout` relation uses a term from the Neurobagel namespace because
 
 ## Sex
 
-Terms are from the SNOMED-CT ontology, which has controlled terms aligning with BIDS `participants.tsv` descriptions for sex.
+Terms are from the SNOMED-CT ontology, which has controlled terms aligning with BIDS `participants.tsv` descriptions for sex.  Below are the SNOMED terms for the sex values allowed by BIDS: 
+
+| Sex    | Controlled term                                                 |
+| ------ | --------------------------------------------------------------- |
+| Male   | http://purl.bioontology.org/ontology/SNOMEDCT/248153007         |
+| Female | http://purl.bioontology.org/ontology/SNOMEDCT/248152002         |
+| Other  | http://purl.bioontology.org/ontology/SNOMEDCT/32570681000036106 |
+
+Here is what a sex annotation looks like in practice:
 
 ```json
 {


### PR DESCRIPTION
<!---
Until this PR is ready for review, you can include the [WIP] tag in its title, or leave it as a github draft.
-->






<!---
This is a suggested pull request template.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue
when this pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.

You can also just link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
Closes #30, closes #28

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers
to indicate what they should be looking for when they review the pull request.
-->
Changes proposed in this pull request:

- Added link to a comprehensive reference example data dictionary (`example_synthetic.json` from the CLI)
- Added table with controlled terms for BIDS-allowed sex values (incl. `Other`)
- Added brief section describing missing values

## Checklist

- [ ] PR has an interpretable title with a prefix (`[ENH]`, `[BUG]`, `[DOC]`, `[INFRA]`, `[MAINT]`)
- [ ] PR links to Github issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Code is properly formatted
