### PR TITLE
[ENH] Update instructions for graph data(base) management

### DIFF
--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -295,17 +295,6 @@ To allow easy (re-)uploading of datasets when needed, we recommend having a shar
 This directory can be called anything you like, but we recommend an explicit name such as `neurobagel_jsonld_datasets` to distinguish it from the actual raw data files or Neurobagel data dictionaries.
 Each `.jsonld` in the directory should include the name of the dataset in the filename.
 
-If you anticipate having to add _new_ datasets to a created graph database in the future, we recommend having a separate directory for JSONLD files of datasets that are already in the graph vs. to be added to the graph, e.g.:
-
-```bash
-neurobagel_jsonld_datasets/
-├── in_graph_database/
-└── not_in_graph/
-```
-
-In this example, JSONLD files for datasets that are not already in the graph should start off in `not_in_graph/`, and then moved to `in_graph_database/` once they have been successfully uploaded. 
-Updates to datasets already in the graph should be pushed from the `in_graph_database/` directory.
-
 ## Test the new deployment
 
 You can run a test query against the API via a `curl` request in your terminal:

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -238,6 +238,22 @@ To view all the command line arguments for add_data_to_graph.sh:
 ./add_data_to_graph.sh --help
 ```
 
+??? info "If you prefer to directly use `curl` requests to modify the graph database instead of the helper script"
+
+    Add a single dataset to the graph database (example)
+    ```bash
+    curl -u "<USERNAME>: <PASSWORD>" -i -X POST http://localhost:5820/<DATABASE_NAME> \
+        -H "Content-Type: application/ld+json" \
+        --data-binary @<DATASET_NAME>.jsonld
+    ```
+    
+    Clear all data in the graph database (example)
+    ```bash
+    curl -u "<USERNAME>: <PASSWORD>" -X POST http://localhost:5820/<DATABASE_NAME>/update \
+        -H "Content-Type: application/sparql-update" \
+        --data-binary "DELETE { ?s ?p ?o } WHERE { ?s ?p ?o }"
+    ```
+
 ### Uploading example Neurobagel data
 In order to test that the [graph setup steps](#setup-for-the-first-run) worked correctly,
 we can add some example graph-ready data to the new graph database.

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -150,6 +150,9 @@ you have two general options:
 When you first launch Stardog, 
 a default `admin` user with superuser privilege
 will automatically be created for you.
+This `admin` user is meant to create other database users and modify their permissions.
+Do not use `admin` for read and write operations, instead use a [regular database user](#create-a-new-database-user).
+
 You should first change the password of the database `admin`:
 
 

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -55,7 +55,7 @@ _** `NB_API_ADDRESS` should not be changed from its default value (`graph`) when
 _&Dagger; See section [Using a graphical query tool to send API requests](#a-note-on-using-a-graphical-query-tool-to-send-api-requests)_
 
 For a local deployment, we recommend to **explicitly set** at least the following variables in `.env`
-(note that the graph username and password must always be set):
+(note that `NB_GRAPH_USERNAME` and `NB_GRAPH_PASSWORD` must always be set):
 
 - `NB_GRAPH_USERNAME`
 - `NB_GRAPH_PASSWORD`
@@ -145,12 +145,12 @@ you have two general options:
     [official docs](https://docs.stardog.com/stardog-applications/studio/) to learn how.
 
 
-### Change the superuser password
+### Change the database admin password
 
 When you first launch Stardog, 
 a default `admin` user with superuser privilege
 will automatically be created for you.
-You should first change the password of this user:
+You should first change the password of the database `admin`:
 
 
 ```console
@@ -158,13 +158,13 @@ curl -X PUT -i -u "admin:admin" http://localhost:5820/admin/users/admin/pwd \
 --data '{"password": "NewPassword"}'
 ```
 
-### Create a new user
+### Create a new database user
 
 The `.env` file created as part of the `docker compose` setup instructions
-declares the `NB_GRAPH_USERNAME` and `NB_GRAPH_PASSWORD` for the API user.
+declares the `NB_GRAPH_USERNAME` and `NB_GRAPH_PASSWORD` for the database user.
 The API will send requests to the graph using these credentials.
 When you launch Stardog for the first time, 
-we have to create this user:
+we have to create a new database user:
 
 ```console
 curl -X POST -i -u "admin:NewPassword" http://localhost:5820/admin/users \
@@ -185,7 +185,7 @@ curl -u "admin:NewPassword" http://localhost:5820/admin/users
 
 !!! note
     Make sure to use the exact `NB_GRAPH_USERNAME` and `NB_GRAPH_PASSWORD` you
-    defined in the `.env` file when creating the new user.
+    defined in the `.env` file when creating the new database user.
     Otherwise the API will not have the correct permission
     to query the graph.
 
@@ -206,7 +206,7 @@ curl -X POST -i -u "admin:NewPassword" http://localhost:5820/admin/databases \
 --form 'root="{\"dbname\":\"test_data\"}"'
 ```
 
-Now we need to give our new user read and write permission for 
+Now we need to give our new database user read and write permission for 
 this database:
 
 ```console
@@ -223,7 +223,7 @@ curl -X PUT -i -u "admin:NewPassword" http://localhost:5820/admin/permissions/us
 
 ??? note "Finer permission control is also possible"
 
-    For simplicity's sake, here we give `"ALL"` permission to the user.
+    For simplicity's sake, here we give `"ALL"` permission to the new database user.
     The Stardog API provide more fine grained permission control.
     See [the official API documentation](https://stardog-union.github.io/http-docs/#tag/Permissions/operation/addUserPermission).
 

--- a/docs/updating_dataset.md
+++ b/docs/updating_dataset.md
@@ -1,0 +1,31 @@
+# Updating a harmonized dataset
+
+When using Neurobagel tools on a dataset that is still undergoing data collection, you may need to update the Neurobagel annotations and/or graph-ready data for the dataset when you want to add new subjects or measurements or to correct mistakes in prior data versions.
+
+For any of the below types of changes, you will need to regenerate a graph-ready `.jsonld` file for the dataset which reflects the change.
+
+## If the phenotypic (tabular) data have changed
+If new variables have been added to the dataset such that there are new columns in the phenotypic TSV you previously annotated using Neurobagel's annotation tool, you will need to:  
+
+1. **Generate an updated data dictionary** by annotating the new variables in your TSV following the [annotation workflow](annotation_tool.md)
+
+2. **Generate a new graph-ready data file** for the dataset by [re-running the CLI](cli.md) on your updated TSV and data dictionary
+
+## If only the imaging data have changed
+If the BIDS data for a dataset have changed without changes in the corresponding phenotypic TSV (e.g., if new modalities or scans have been acquired for a subject), you have two options:
+
+a. If you still have access to the dataset's phenotypic JSONLD generated from the `pheno` command of the `bagel-cli` (step 1), you may choose to [rerun only the `bids` CLI command](cli.md) on the updated BIDS directory. 
+This will generate a new graph-ready data file with updated imaging metadata of subjects.
+
+b. [Rerun the CLI entirely (`pheno` and `bids` steps)](cli.md) to generate a new graph-ready data file for the dataset.
+
+_When in doubt, go with option b._
+
+## If only the subjects have changed
+If subjects have been added to or removed from the dataset, but the phenotypic TSV otherwise has been unchanged (e.g., only new or removed rows), you will need to:
+
+1. **Generate a new graph-ready data file** for the dataset by [re-running the CLI](cli.md) (`pheno` and `bids` steps) on your updated TSV and existing data dictionary
+
+## Updating the graph database
+To allow easy (re-)uploading of the updated `.jsonld` for your dataset to a graph database, make a copy of it in a [central directory on your research data fileserver for storing local Neurobagel `jsonld` datasets](infrastructure.md#where-to-store-neurobagel-graph-ready-data). 
+Then, follow the steps for [uploading/updating a dataset in the graph database](infrastructure.md#uploading-data-to-the-graph) (needs to be completed by user with database write access).

--- a/docs/updating_dataset.md
+++ b/docs/updating_dataset.md
@@ -14,17 +14,19 @@ If new variables have been added to the dataset such that there are new columns 
 ## If only the imaging data have changed
 If the BIDS data for a dataset have changed without changes in the corresponding phenotypic TSV (e.g., if new modalities or scans have been acquired for a subject), you have two options:
 
-a. If you still have access to the dataset's phenotypic JSONLD generated from the `pheno` command of the `bagel-cli` (step 1), you may choose to [rerun only the `bids` CLI command](cli.md) on the updated BIDS directory. 
+- If you still have access to the dataset's phenotypic JSONLD generated from the `pheno` command of the `bagel-cli` (step 1), you may choose to [rerun only the `bids` CLI command](cli.md) on the updated BIDS directory. 
 This will generate a new graph-ready data file with updated imaging metadata of subjects.
 
-b. [Rerun the CLI entirely (`pheno` and `bids` steps)](cli.md) to generate a new graph-ready data file for the dataset.
+OR
 
-_When in doubt, go with option b._
+- [Rerun the CLI entirely (`pheno` and `bids` steps)](cli.md) to generate a new graph-ready data file for the dataset.
+
+_When in doubt, rerun both CLI commands._
 
 ## If only the subjects have changed
-If subjects have been added to or removed from the dataset, but the phenotypic TSV otherwise has been unchanged (e.g., only new or removed rows), you will need to:
+If subjects have been added to or removed from the dataset but the phenotypic TSV is otherwise unchanged (i.e., only new or removed rows, without changes to the available variables), you will need to:
 
-1. **Generate a new graph-ready data file** for the dataset by [re-running the CLI](cli.md) (`pheno` and `bids` steps) on your updated TSV and existing data dictionary
+- **Generate a new graph-ready data file** for the dataset by [re-running the CLI](cli.md) (`pheno` and `bids` steps) on your updated TSV and existing data dictionary
 
 ## Updating the graph database
 To allow easy (re-)uploading of the updated `.jsonld` for your dataset to a graph database, make a copy of it in a [central directory on your research data fileserver for storing local Neurobagel `jsonld` datasets](infrastructure.md#where-to-store-neurobagel-graph-ready-data). 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
     - Annotating a dataset: "annotation_tool.md"
     - Generating harmonized subject-level metadata: "cli.md"
     - Setting up a graph: "infrastructure.md"
+    - Updating a harmonized dataset: "updating_dataset.md"
     - Using the API: "api.md"
     - Running cohort queries: "query_tool.md"
   - Data models: 


### PR DESCRIPTION
<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
Closes #52 
Closes #24
Closes #20 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Add instructions to use `add_data_to_graph.sh` to upload + update datasets in graph
- Add new page describing steps to regenerate JSONLD files when a dataset has been updated
- Add recommendation for where to keep `.jsonld` outputs created by the CLI for multiple datasets
- Used clearer language to describe database admin vs. user

<!-- To be checked off by reviewers -->
## Checklist

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Checks pass
