### PR TITLE
[FIX] Recommend to change `NB_GRAPH_ROOT_HOST` for GraphDB

### DIFF
--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -111,6 +111,7 @@ Below are all the possible Neurobagel environment variables that can be set in `
         ```bash
         NB_GRAPH_IMG=ontotext/graphdb:10.3.1
         NB_GRAPH_ROOT_CONT=/opt/graphdb/home
+        NB_GRAPH_ROOT_HOST=~/graphdb-home  # Or, replace with another directory on your own (host) system where you want to store the database files
         NB_GRAPH_PORT=7200
         NB_GRAPH_PORT_HOST=7200
         NB_GRAPH_DB=repositories/my_db  # For graphDB, this value should always take the format of: repositories/<your_database_name>


### PR DESCRIPTION
<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Explicitly provide a sensible path to use for `NB_GRAPH_ROOT_HOST` that is specific to the GraphDB deployment (previously, the container would default to using `stardog_root` for both backends since we don't instruct users to change the path for GraphDB)
 
<!-- To be checked off by reviewers -->
## Checklist

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Checks pass
