### PR TITLE
[FIX] Remove `--clear-data` flag from vocab file upload command

### DIFF
--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -566,15 +566,14 @@ Run the following code (assumes you are in the `api` directory):
 === "Stardog"
     ``` bash
     ./add_data_to_graph.sh vocab \
-      localhost:5820 test_data DBUSER DBPASSWORD \
-      --clear-data
+      localhost:5820 test_data DBUSER DBPASSWORD
     ```
 
 === "graphDB"
     ``` bash
     ./add_data_to_graph.sh vocab \
       localhost:7200 repositories/my_db DBUSER DBPASSWORD \
-      --clear-data --use-graphdb-syntax
+      --use-graphdb-syntax
     ```
 
 ### Updating a dataset in the graph database


### PR DESCRIPTION
<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

We don't want to clear the existing data in the graph when we add the vocabulary file!! 😱

<!-- To be checked off by reviewers -->
## Checklist

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Checks pass
