### PR TITLE
[ENH] Clarify PR merging responsibility

### DIFF
--- a/docs/contributing/pull_requests.md
+++ b/docs/contributing/pull_requests.md
@@ -33,6 +33,6 @@ Neurobagel PR reviews may use the following emoji signifiers:
 If (required) changes are requested, the PR author should re-request a review from the reviewer once the comments have been addressed.
 
 ### When your pull request is approved
-For PRs opened by community contributors, the reviewing Neurobagel maintainer is responsible for merging the PR.
+If you **are not a member of the Neurobagel developer team**: the reviewing Neurobagel maintainer is responsible for merging the PR.
 
-For PRs opened by Neurobagel developers, the PR author is responsible for merging the PR.
+If you **are a member of the Neurobagel developer team** (i.e., you have write access to the repository): the PR author is responsible for merging the PR.

--- a/docs/contributing/pull_requests.md
+++ b/docs/contributing/pull_requests.md
@@ -22,7 +22,7 @@ Instead, for documentation content changes, the following prefixes can be used t
 - `[FIX]`: Fixing errors in the documentation
 
 ## Pull request reviews
-A developer will review each PR and may provide comments or suggestions for the PR author to address.
+A core maintainer will review each PR and may provide comments or suggestions for the PR author to address.
 
 Neurobagel PR reviews may use the following emoji signifiers:
 
@@ -31,3 +31,8 @@ Neurobagel PR reviews may use the following emoji signifiers:
 :cherries:: Some optional/suggested changes that could be nice to have but are not required to merge
 
 If (required) changes are requested, the PR author should re-request a review from the reviewer once the comments have been addressed.
+
+### When your pull request is approved
+For PRs opened by community contributors, the reviewing Neurobagel maintainer is responsible for merging the PR.
+
+For PRs opened by Neurobagel developers, the PR author is responsible for merging the PR.


### PR DESCRIPTION
<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
Closes #108

See also https://github.com/neurobagel/.github/pull/7

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->


<!-- To be checked off by reviewers -->
## Checklist

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Checks pass
