### PR TITLE
[REF] rename graph API to backend endpoint

### DIFF
--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -203,7 +203,7 @@ you have two general options:
 
 === "Stardog"
 
-    1. Send HTTP request against the HTTP API of the Stardog graph instance (e.g. with `curl`). See [https://stardog-union.github.io/http-docs/](https://stardog-union.github.io/http-docs/) for a full reference of API endpoints
+    1. Send HTTP request from the neurobagel API to the HTTP REST endpoints of the Stardog graph backend (e.g. with `curl`). See [https://stardog-union.github.io/http-docs/](https://stardog-union.github.io/http-docs/) for a full reference of API endpoints
     2. Use the free Stardog-Studio web app. See the [Stardog documentation](https://docs.stardog.com/stardog-applications/dockerized_access#stardog-studio) for instruction to deploy Stardog-Studio as a Docker container.
 
 
@@ -218,7 +218,7 @@ you have two general options:
 
 === "graphDB"
 
-    1. Send HTTP requests against the HTTP API of the graphDB backend 
+    1. Send HTTP requests fromt the neurobagel API to the HTTP REST endpoints of thethe graphDB backend 
     e.g. using `curl`. graphDB uses the [RDF4J API](https://rdf4j.org/documentation/reference/rest-api/) specification.
     2. Use the graphDB web interface (called [the workbench](https://graphdb.ontotext.com/documentation/10.0/architecture-components.html)). 
     Once your local graphDB backend is running

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -218,7 +218,7 @@ you have two general options:
 
 === "graphDB"
 
-    1. Send HTTP requests fromt the neurobagel API to the HTTP REST endpoints of thethe graphDB backend 
+    1. Send HTTP requests from the neurobagel API to the HTTP REST endpoints of thethe graphDB backend 
     e.g. using `curl`. graphDB uses the [RDF4J API](https://rdf4j.org/documentation/reference/rest-api/) specification.
     2. Use the graphDB web interface (called [the workbench](https://graphdb.ontotext.com/documentation/10.0/architecture-components.html)). 
     Once your local graphDB backend is running

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -218,7 +218,7 @@ you have two general options:
 
 === "graphDB"
 
-    1. Send HTTP requests from the neurobagel API to the HTTP REST endpoints of thethe graphDB backend 
+    1. Send HTTP requests from the neurobagel API to the HTTP REST endpoints of the graphDB backend 
     e.g. using `curl`. graphDB uses the [RDF4J API](https://rdf4j.org/documentation/reference/rest-api/) specification.
     2. Use the graphDB web interface (called [the workbench](https://graphdb.ontotext.com/documentation/10.0/architecture-components.html)). 
     Once your local graphDB backend is running


### PR DESCRIPTION
To better differentiate from our own API

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes https://github.com/neurobagel/api/issues/121

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

-
-

<!-- To be checked off by reviewers -->
## Checklist

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Checks pass
