### PR TITLE
[FIX] Add "ses-" prefix to sessions in Nipoppy configs page

### DIFF
--- a/docs/nipoppy/configs.md
+++ b/docs/nipoppy/configs.md
@@ -36,7 +36,7 @@ Nipoppy requires two global files for specifying local data/container paths and 
     "SINGULARITY_PATH": "singularity",
     "TEMPLATEFLOW_DIR": "/path/to/templateflow",
 
-    "SESSIONS": ["1","5","7","9","11"],
+    "SESSIONS": ["ses-1","ses-5","ses-7","ses-9","ses-11"],
 
     "BIDS": {
         "heudiconv": {


### PR DESCRIPTION
<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
Closes #151.

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Add `"ses-"` prefix to sessions under `"SESSIONS"` key in example `global_configs.json` file

<!-- To be checked off by reviewers -->
## Checklist

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Checks pass
