### PR TITLE
[REF] update syntax for data upload script

### DIFF
--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -487,14 +487,14 @@ Next, upload the `.jsonld` file in the directory `neurobagel_examples/data-uploa
     ``` bash
     ./add_data_to_graph.sh PATH/TO/neurobagel_examples/data-upload/pheno-bids-output \
       localhost:7200 repositories/my_db DBUSER DBPASSWORD \
-      --clear-data --use-graphdb-syntax
+      --clear-data
     ```
 
 === "Stardog"
     ``` bash
     ./add_data_to_graph.sh PATH/TO/neurobagel_examples/data-upload/pheno-bids-output \
       localhost:5820 test_data DBUSER DBPASSWORD \
-      --clear-data
+      --clear-data --use-stardog-syntax
     ```
 
 **Note:** Here we added the `--clear-data` flag to remove any existing data in the database (if the database is empty, the flag has no effect).
@@ -533,14 +533,14 @@ Run the following code (assumes you are in the `api` directory):
 === "GraphDB"
     ``` bash
     ./add_data_to_graph.sh vocab \
-      localhost:7200 repositories/my_db DBUSER DBPASSWORD \
-      --use-graphdb-syntax
+      localhost:7200 repositories/my_db DBUSER DBPASSWORD
     ```
 
 === "Stardog"
     ``` bash
     ./add_data_to_graph.sh vocab \
-      localhost:5820 test_data DBUSER DBPASSWORD
+      localhost:5820 test_data DBUSER DBPASSWORD \
+      --use-stardog-syntax
     ```
 
 ### Updating a dataset in the graph database


### PR DESCRIPTION
Because of https://github.com/neurobagel/recipes/pull/13 we now default to using graphDB syntax. This updates the docs to show the new behaviour

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
Closes https://github.com/neurobagel/recipes/issues/3

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- update examples of `add_data_to_graph.sh` to comply with changes in https://github.com/neurobagel/recipes/pull/13

<!-- To be checked off by reviewers -->
## Checklist

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Checks pass
