### PR TITLE
[ENH] Add top-level note in Nipoppy pages about new Read the Docs website 

### DIFF
--- a/docs/nipoppy/cli_note.md
+++ b/docs/nipoppy/cli_note.md
@@ -1,4 +1,4 @@
-!!! note
+!!! note "Nipoppy docs are moving"
 
     Nipoppy is undergoing a major refactor to move from scripts to a 
     command-line interface (CLI) and Python API. The new documentation website

--- a/docs/nipoppy/cli_note.md
+++ b/docs/nipoppy/cli_note.md
@@ -1,0 +1,9 @@
+!!! note
+
+    Nipoppy is undergoing a major refactor to move from scripts to a 
+    command-line interface (CLI) and Python API. The new documentation website
+    (work in progress) can be found at [nipoppy.readthedocs.io](nipoppy.readthedocs.io).
+
+    If you are using the (soon-to-be legacy) scripts from Nipoppy 0.1.0, this is
+    still the correct place to be. But we encourage you to check out the new
+    website!

--- a/docs/nipoppy/code_org.md
+++ b/docs/nipoppy/code_org.md
@@ -1,3 +1,7 @@
+{%
+    include-markdown "nipoppy/cli_note.md"
+%}
+
 ## Code organization
 
 ---

--- a/docs/nipoppy/configs.md
+++ b/docs/nipoppy/configs.md
@@ -1,3 +1,7 @@
+{%
+    include-markdown "nipoppy/cli_note.md"
+%}
+
 ## Global files
 
 ---

--- a/docs/nipoppy/data_org.md
+++ b/docs/nipoppy/data_org.md
@@ -1,3 +1,7 @@
+{%
+    include-markdown "nipoppy/cli_note.md"
+%}
+
 ## Data organization
 
 ---

--- a/docs/nipoppy/glossary.md
+++ b/docs/nipoppy/glossary.md
@@ -1,3 +1,7 @@
+{%
+    include-markdown "nipoppy/cli_note.md"
+%}
+
 ## Glossary
 
 This page lists some definitions for important/recurring terms used in the Nipoppy framework.

--- a/docs/nipoppy/installation.md
+++ b/docs/nipoppy/installation.md
@@ -1,3 +1,7 @@
+{%
+    include-markdown "nipoppy/cli_note.md"
+%}
+
 ## Code installation and dataset setup
 
 ---

--- a/docs/nipoppy/overview.md
+++ b/docs/nipoppy/overview.md
@@ -1,3 +1,7 @@
+{%
+    include-markdown "cli_note.md"
+%}
+
 ## What is Nipoppy? 
 
 [Nipoppy](https://github.com/neurodatascience/nipoppy) is a lightweight framework for analyzing (neuro)imaging and clinical data. It is designed to help users do the following:

--- a/docs/nipoppy/overview.md
+++ b/docs/nipoppy/overview.md
@@ -1,5 +1,5 @@
 {%
-    include-markdown "cli_note.md"
+    include-markdown "nipoppy/cli_note.md"
 %}
 
 ## What is Nipoppy? 

--- a/docs/nipoppy/trackers.md
+++ b/docs/nipoppy/trackers.md
@@ -1,3 +1,7 @@
+{%
+    include-markdown "nipoppy/cli_note.md"
+%}
+
 ## Track data availability status
 
 ---

--- a/docs/nipoppy/workflow/bids_conv.md
+++ b/docs/nipoppy/workflow/bids_conv.md
@@ -1,3 +1,7 @@
+{%
+    include-markdown "nipoppy/cli_note.md"
+%}
+
 ## Objective
 
 ---

--- a/docs/nipoppy/workflow/dicom_org.md
+++ b/docs/nipoppy/workflow/dicom_org.md
@@ -1,3 +1,7 @@
+{%
+    include-markdown "nipoppy/cli_note.md"
+%}
+
 ## Objective
 
 ---

--- a/docs/nipoppy/workflow/proc_pipe/fmriprep.md
+++ b/docs/nipoppy/workflow/proc_pipe/fmriprep.md
@@ -1,3 +1,7 @@
+{%
+    include-markdown "nipoppy/cli_note.md"
+%}
+
 ## Objective
 
 ---

--- a/docs/nipoppy/workflow/proc_pipe/mriqc.md
+++ b/docs/nipoppy/workflow/proc_pipe/mriqc.md
@@ -1,3 +1,7 @@
+{%
+    include-markdown "nipoppy/cli_note.md"
+%}
+
 ## MRIQC image processing pipeline
 
 ---


### PR DESCRIPTION
<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #192 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Added a "Note" block at the top of every Nipoppy page, for example:
  ![Screenshot 2024-05-07 at 7 41 54 PM](https://github.com/neurobagel/documentation/assets/29051929/96f022f8-793b-4544-a429-a340fa759e2f)

  

<!-- To be checked off by reviewers -->
## Checklist
_Please leave checkboxes empty for PR reviewers_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`) _see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING/#pull-request-guidelines) for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Checks pass
