### PR TITLE
[FIX] Apply tailwind stylesheet just in home.html

### DIFF
--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -1,6 +1,11 @@
 <!-- Custom HTML site displayed as the Home chapter -->
 {% extends "main.html" %}
 
+{% block styles %}
+{{ super() }}
+<link href="../stylesheets/output.css" rel="stylesheet">
+{% endblock %}
+
 {% block tabs %}
 {{ super() }}
 

--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -1,8 +1,0 @@
-/* 
-This file only exists to prevent the tailwind styles for ordered lists from being applied
-If we don't do this, all ordered list elements will become invisible.
- */
-ol,
-menu {
-  list-style: decimal;
-}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,7 +110,3 @@ plugins:
 extra:
   analytics:
     provider: plausible
-
-extra_css:
-  - stylesheets/output.css
-  - stylesheets/custom.css


### PR DESCRIPTION
<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #203 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- This PR fixes the problem where tailwind was being made to override mkdocs styles on docs pages other than the homepage, which was resulting in disrupted formatting for mkdocs material elements and text.

<!-- To be checked off by reviewers -->
## Checklist
_Please leave checkboxes empty for PR reviewers_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`) _see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING/#pull-request-guidelines) for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Checks pass
