### PR TITLE
[ENH] Add Discord link and mention semver label in `latest` images

### DIFF
--- a/docs/getting_help.md
+++ b/docs/getting_help.md
@@ -2,23 +2,23 @@
 
 There are several ways to interact with the Neurobagel team, including:
 
-- Issues in our [GitHub repositories](https://github.com/neurobagel)
-- Our [Neurostars forum](https://neurostars.org/tag/neurobagel)
-- Our [Discord server](https://discord.gg/BEXXgt3hXk)
+- Create an issue in our [GitHub repositories](https://github.com/neurobagel)
+- Our tag on the [Neurostars forum](https://neurostars.org/tag/neurobagel)
+- Join our [Discord server](https://discord.gg/BEXXgt3hXk) to chat with us
 
 ## Usage or general questions
 If you have a _usage question_ about Neurobagel (e.g., troubleshooting setup, feedback on a specific use case), 
 or want to _discuss the Neurobagel project in general_ with the development team or other users, 
 please either:
 
-- open an issue on Neurostars with the `neurobagel` tag: [https://neurostars.org/tag/neurobagel](https://neurostars.org/tag/neurobagel) or
+- search for or start a new thread on Neurostars with the `neurobagel` tag: [https://neurostars.org/tag/neurobagel](https://neurostars.org/tag/neurobagel) or
 - send us a message in the [Neurobagel Discord server](https://discord.gg/BEXXgt3hXk)
 
 ## Report a bug or request a feature
 For _bug reports_ or _feature requests_, we prefer if you open an issue in the repository for the relevant tool in the [Neurobagel GitHub organization](https://github.com/neurobagel).
 
 If you are using one of our web tools ([https://annotate.neurobagel.org](https://annotate.neurobagel.org) or [https://query.neurobagel.org](https://query.neurobagel.org)), 
-you may also submit bug reports and feature requests using the feedback widget directly on the site.
+you may also submit bug reports and feature requests using the feedback widget directly on the app.
 
 ## Documentation feedback
 We are always looking to improve our user documentation.

--- a/docs/getting_help.md
+++ b/docs/getting_help.md
@@ -1,13 +1,25 @@
 # Getting Help
 
-## Report a bug or request a feature
-For a bug or feature request, feel free to open an issue in the repository for the relevant tool in the [Neurobagel GitHub organization](https://github.com/neurobagel).
+There are several ways to interact with the Neurobagel team, including:
 
-If you are using one of our web tools ([https://annotate.neurobagel.org](https://annotate.neurobagel.org) or [https://query.neurobagel.org](https://query.neurobagel.org), you can also submit suggestions and bugs using the feedback widget directly on the site.
+- Issues in our [GitHub repositories](https://github.com/neurobagel)
+- Our [Neurostars forum](https://neurostars.org/tag/neurobagel)
+- Our [Discord server](https://discord.gg/BEXXgt3hXk)
+
+## Usage or general questions
+If you have a _usage question_ about Neurobagel (e.g., troubleshooting setup, feedback on a specific use case), 
+or want to _discuss the Neurobagel project in general_ with the development team or other users, 
+please either:
+
+- open an issue on Neurostars with the `neurobagel` tag: [https://neurostars.org/tag/neurobagel](https://neurostars.org/tag/neurobagel) or
+- send us a message in the [Neurobagel Discord server](https://discord.gg/BEXXgt3hXk)
+
+## Report a bug or request a feature
+For _bug reports_ or _feature requests_, we prefer if you open an issue in the repository for the relevant tool in the [Neurobagel GitHub organization](https://github.com/neurobagel).
+
+If you are using one of our web tools ([https://annotate.neurobagel.org](https://annotate.neurobagel.org) or [https://query.neurobagel.org](https://query.neurobagel.org)), 
+you may also submit bug reports and feature requests using the feedback widget directly on the site.
 
 ## Documentation feedback
 We are always looking to improve our user documentation.
 To request a change or addition to existing documentation, please [open an issue in the `neurobagel/documentation` repo](https://github.com/neurobagel/documentation/issues).
-
-## General questions
-For general questions about Neurobagel, please open an issue on Neurostars with the `neurobagel` tag: [https://neurostars.org/tag/neurobagel](https://neurostars.org/tag/neurobagel).

--- a/docs/getting_help.md
+++ b/docs/getting_help.md
@@ -1,6 +1,6 @@
 # Getting Help
 
-There are several ways to interact with the Neurobagel team, including:
+There are several ways you can interact with the Neurobagel team:
 
 - Create an issue in our [GitHub repositories](https://github.com/neurobagel)
 - Our tag on the [Neurostars forum](https://neurostars.org/tag/neurobagel)

--- a/docs/maintaining.md
+++ b/docs/maintaining.md
@@ -9,7 +9,7 @@ We are continuously improving Neurobagel tools and services,
 so you may want to update your Neurobagel node to the latest version to benefit from new features and bug fixes.
 We always publish our tools as [Docker images on DockerHub](https://hub.docker.com/repositories/neurobagel).
 
-Each Docker image has a semantic version tag (vX.Y.Z), and also two rolling tags:
+Each Docker image has a [semantic version](https://semver.org/) tag (vX.Y.Z), and also two rolling tags:
 
 - `latest` (the latest stable release). This is the default tag used in the Neurobagel `docker-compose.yml` file.
 - `nightly` (the latest build from the main branch). This tag is only used for compatibility testing and should not be used in production.

--- a/docs/maintaining.md
+++ b/docs/maintaining.md
@@ -56,21 +56,6 @@ docker compose --profile full_stack pull
 Whether you have updated the Docker images, the [configuration](config.md), or the [data](#updating-the-data-in-your-graph)
 of your Neurobagel node, you will need to restart the services to apply the changes.
 
-!!! warning "Restarting the graph backend after an update can introduce problems"
-
-    If you have updated the data model or the data in your graph,
-    you should **not** restart the graph backend services without first updating the data in the graph.
-    
-    This is a current limitation of the deployment profile and we are working to resolve it.
-
-    In the meantime, here is how you can restart and update the services in your Neurobagel node
-    without affecting the graph backend: 
-
-    ```bash
-    docker compose down api query_federation federation
-    docker compose pull && docker compose up -d
-    ```
-
 To shut down a running Neurobagel node,
 navigate to the path on your file system where
 you have stored the `docker-compose.yml` file from the [initial setup](getting_started.md) and run:

--- a/docs/maintaining.md
+++ b/docs/maintaining.md
@@ -7,9 +7,9 @@ there are some recurring tasks you may have to do to keep it operating correctly
 
 We are continuously improving Neurobagel tools and services,
 so you may want to update your Neurobagel node to the latest version to benefit from new features and bug fixes.
-We always publish our tools as [Docker images on Dockerhub](https://hub.docker.com/repositories/neurobagel).
+We always publish our tools as [Docker images on DockerHub](https://hub.docker.com/repositories/neurobagel).
 
-Each Docker image has a version tag, and also two rolling tags:
+Each Docker image has a semantic version tag (vX.Y.Z), and also two rolling tags:
 
 - `latest` (the latest stable release). This is the default tag used in the Neurobagel `docker-compose.yml` file.
 - `nightly` (the latest build from the main branch). This tag is only used for compatibility testing and should not be used in production.
@@ -19,6 +19,29 @@ You can pull the most recent docker images for Neurobagel tools by running:
 ```bash
 docker compose --profile full_stack pull
 ```
+
+??? tip "Not sure what version you have?"
+
+    Since `latest` is a rolling tag, each `latest` Docker image for a Neurobagel tool includes its corresponding semver number (vX.Y.X) as part of its Docker image labels.
+
+    You can find the labels for an image you have pulled in the image metadata, e.g.:
+    ```bash
+    docker image inspect neurobagel/api:latest
+    ```
+    or, to view only the labels:
+    ```bash
+    docker image inspect --format='{{json .Config.Labels}}' neurobagel/api:latest
+    ```
+    In either case, you should see something like this in the output:
+
+    ```bash
+        "Labels": {
+            "org.opencontainers.image.created": "https://github.com/neurobagel/api",
+            "org.opencontainers.image.revision": "01530f467e163f3dff595d3327bc60ba453de47d",
+            "org.opencontainers.image.version": "v0.3.1"
+        }
+    ```
+    where `"org.opencontainers.image.version"` refers to the version number.
 
 !!! warning "`docker compose` will only pull the images that are used by the current deployment profile."
 

--- a/md_link_check_config.json
+++ b/md_link_check_config.json
@@ -1,12 +1,13 @@
 {
     "ignorePatterns": [
-        {"pattern": "http://neurobagel.org/vocab/*"},
+        {"pattern": "http://neurobagel.org/vocab/.*"},
         {"pattern": "http://neurobagel.org/graph/"},
         {"pattern": "https://www.cognitiveatlas.org/task/id/"},
-        {"pattern": "^../"},
-        {"pattern": "localhost*"},
-        {"pattern": "https://api.neurobagel.org/*"},
-        {"pattern": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#"}
+        {"pattern": "^../.*"},
+        {"pattern": ".*localhost.*"},
+        {"pattern": "https://api.neurobagel.org/.*"},
+        {"pattern": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#"},
+        {"pattern": "https://github.com/neurodatascience/nipoppy/.*"}
     ],
     "timeout": "60s"
 }


### PR DESCRIPTION
<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #220 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Slight restructuring of "Getting Help" page based on type of question
- Explain how to find semver for a `latest` Neurobagel image
- Remove outdated note about needing to manually update data in the graph before restarting services (happens automatically as of https://github.com/neurobagel/recipes/pull/57)

<!-- To be checked off by reviewers -->
## Checklist
_Please leave checkboxes empty for PR reviewers_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`) _see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING/#pull-request-guidelines) for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Checks pass
