### PR TITLE
[MNT] Replace Cognitive Atlas with SNOMED CT as the vocab for assessments

### DIFF
--- a/docs/data_models/dictionaries.md
+++ b/docs/data_models/dictionaries.md
@@ -120,8 +120,7 @@ syntax for [json-ld](https://w3c.github.io/json-ld-syntax/#the-context):
     "nb": "http://neurobagel.org/vocab/",
     "ncit": "http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#",
     "nidm": "http://purl.org/nidash/nidm#",
-    "snomed": "http://purl.bioontology.org/ontology/SNOMEDCT/",
-    "cogatlas": "https://www.cognitiveatlas.org/task/id/"
+    "snomed": "http://purl.bioontology.org/ontology/SNOMEDCT/"
   }
 }
 ```
@@ -187,8 +186,8 @@ Term from the Neurobagel vocabulary.
 
 ### Diagnosis
 
-Terms from the [SNOMED-CT ontology](https://browser.ihtsdotools.org/) for clinical diagnosis.
-Terms from the National Cancer Institute Thesaurus for healthy control status.
+Terms for clinical diagnosis are from the [SNOMED-CT ontology](https://browser.ihtsdotools.org/).
+Terms for healthy control status are from the National Cancer Institute Thesaurus.
 
 ```json hl_lines="10-11 13 15-16 19-20"
 {
@@ -307,6 +306,8 @@ Possible heuristics:
 
 ### Assessment tool
 
+Terms are from the SNOMED-CT ontology.
+
 For assessment tools like cognitive tests or rating scales, 
 Neurobagel encodes whether a subject has a value/score for _at least one_ item or subscale of the assessment.
 Because assessment tools often have several subscales or items 
@@ -330,8 +331,8 @@ when instances of missing values are present (see also section [Missing values](
         "Label": "Assessment tool"
       },
       "IsPartOf": {
-        "TermURL": "cogatlas:tsk_4a57abb949ece",
-        "Label": "Unified Parkinson's Disease Rating Scale"
+        "TermURL": "snomed:342061000000106",
+        "Label": "Unified Parkinsons disease rating scale score"
       }
     }
   },
@@ -343,8 +344,8 @@ when instances of missing values are present (see also section [Missing values](
         "Label": "Assessment tool"
       },
       "IsPartOf": {
-        "TermURL": "cogatlas:tsk_4a57abb949ece",
-        "Label": "Unified Parkinson's Disease Rating Scale"
+        "TermURL": "snomed:342061000000106",
+        "Label": "Unified Parkinsons disease rating scale score"
       },
       "MissingValues": [""]
     }

--- a/docs/data_models/term_naming_standards.md
+++ b/docs/data_models/term_naming_standards.md
@@ -2,7 +2,7 @@
 
 ## Naming conventions
 ### Namespace prefixes
-- Names should be all lowercase (e.g., `nidm`, `cogatlas`)
+- Names should be all lowercase (e.g., `nidm`, `snomed`)
 
 ### Properties (graph "edges")
 - Names should adhere to camelCase (uses capitalized words except for the first word/letter)
@@ -27,14 +27,13 @@ What this might look like in semantic triples:
     In cases where we reuse a term for a class that comes from an existing controlled vocabulary, and that vocabulary follows a different naming convention (e.g., all lowercase), we should follow the existing naming convention.
 
 ## Currently used namespaces
-| Prefix     | IRI                                                 | Types of terms                            |
-| ---------- | --------------------------------------------------- | ----------------------------------------- |
-| `nb`       | http://neurobagel.org/vocab/                        | Neurobagel-"owned" properties and classes |
-| `nbg`      | http://neurobagel.org/graph/                        | Neurobagel graph databases                |
-| `snomed`   | http://purl.bioontology.org/ontology/SNOMEDCT/      | diagnosis and sex values                  |
-| `ncit`     | http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl# | group designation (e.g., healthy control) |
-| `nidm`     | http://purl.org/nidash/nidm#                        | imaging modalities                        |
-| `cogatlas` | https://www.cognitiveatlas.org/task/id/             | cognitive assessments and tasks           |
+| Prefix | IRI | Types of terms |
+| ----- | ----- | ----- |
+| `nb` | http://neurobagel.org/vocab/ | Neurobagel-"owned" properties and classes |
+| `snomed` | http://purl.bioontology.org/ontology/SNOMEDCT/ | diagnoses, sex, and assessments or instruments |
+| `ncit` | http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl# | group designation (e.g., healthy control) |
+| `nidm` | http://purl.org/nidash/nidm# | imaging modalities |
+| `np` | https://github.com/nipoppy/pipeline-catalog/tree/main/processing/ | processing pipeline and derivative metadata |
 
 
 ## What if an `nb` term already exists in another controlled vocabulary?

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -199,7 +199,7 @@
                 <h2 class="text-3xl font-bold tracking-tight text-white sm:text-3xl">
                     Work with standardized terminologies
                 </h2>
-                <p class="mt-6 text-lg leading-8 text-gray-300">Reap the benefits of curated vocabularies (e.g., BIDS, SNOMED CT, and the Cognitive Atlas) and linked data, without the implementation expertise.</p>
+                <p class="mt-6 text-lg leading-8 text-gray-300">Reap the benefits of curated vocabularies (e.g., BIDS, SNOMED CT, and NIDM) and linked data, without the implementation expertise.</p>
                 <div class="mt-10 flex items-center justify-center gap-x-6 lg:justify-start">
                     <a href="/dictionaries" class="text-sm font-semibold leading-6 text-white">Learn more <span
                             aria-hidden="true">→</span></a>


### PR DESCRIPTION
<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #251 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->

<!-- To be checked off by reviewers -->
## Checklist
_Please leave checkboxes empty for PR reviewers_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`) _see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING/#pull-request-guidelines) for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Checks pass
- [x] Remember to check all checkboxes during review
