### PR TITLE
[DOC] Added docker-compose.yml to configure caddy as a reverse proxy

### DIFF
--- a/docs/user_guide/config.md
+++ b/docs/user_guide/config.md
@@ -194,152 +194,269 @@ This file adds:
 - [nginx-proxy](https://github.com/nginx-proxy/nginx-proxy) to run NGINX in a container, and automatically generate/refresh NGINX reverse proxy configurations when Neurobagel service containers are started
 - [acme-companion](https://github.com/nginx-proxy/acme-companion) to automatically create and renew SSL certificates for NGINX proxied service containers
 
-??? abstract "Example `docker-compose.yml` with NGINX reverse proxy"
+
+!!! warning "Community Contribution"
+        
+    **Disclaimer:** This example `docker-compose.yml` is a community-contributed resource and is not officially maintained or supported by the Neurobagel team.
+
+    **Compatibility Note:** This example has been tested with version `v0.4.1` of the [Neurobagel deployment recipes](https://github.com/neurobagel/recipes). Ensure you are using the same or a compatible version for optimal results.
+
+??? abstract "Example `docker-compose.yml` with reverse proxy"
     To use this file:
 
-    1. If you haven't already, follow the [steps](getting_started.md#the-neurobagel-node-deployment-recipe) to clone and minimally configure the services in the [Neurobagel deployment recipe](https://github.com/neurobagel/recipes)
-    2. Replace the default `docker-compose.yml` in the `recipes` directory with the below file
-    2. Open the file, and edit the values of `VIRTUAL_HOST` and `LETSENCRYPT_HOST` to the domains your proxied services will use (see  :material-plus-circle:)
-        - This assumes you have already registered your domain(s) with a DNS provider and configured the DNS settings to resolve correctly to your host machine
-
-    3. From the root of the `recipes` directory, run:
+    1. If you haven't already, follow the [steps](getting_started.md#the-neurobagel-node-deployment-recipe) to clone and minimally configure the services in the [Neurobagel deployment recipe](https://github.com/neurobagel/recipes).
+    2. Replace the default `docker-compose.yml` in the `recipes` directory with the below file.
+    3. Open the file, and edit the values of `VIRTUAL_HOST` and `LETSENCRYPT_HOST` to the domains your proxied services will use.
+       - This assumes you have already registered your domain(s) with a DNS provider and configured the DNS settings to resolve correctly to your host machine.
+    4. From the root of the `recipes` directory, run:
         ```bash
         docker compose up -d
         ```
-        (or, see [here](#available-profiles) to launch a non-default service profile)
-    4. Ensure that ports 80 and 443 are open on the host machine where your Docker Compose stack is running
+        (or, see [here](#available-profiles) to launch a non-default service profile).
+    5. Ensure that ports 80 and 443 are open on the host machine where your Docker Compose stack is running.
 
-    ```{ .yaml .annotate title="docker-compose.yml" }
-    services:
+    === "NGINX(`docker-compose.yml`)"
+        ```yaml
+        services:
 
-      api:
-        image: "neurobagel/api:${NB_NAPI_TAG:-latest}"
-        profiles:
-          - "local_node"
-          - "full_stack"
-        ports:
-          - "${NB_NAPI_PORT_HOST:-8000}:8000"
-        environment:
-          NB_GRAPH_USERNAME: ${NB_GRAPH_USERNAME}
-          NB_GRAPH_ADDRESS: graph
-          NB_GRAPH_PORT: 7200
-          NB_GRAPH_DB: ${NB_GRAPH_DB:-repositories/my_db}
-          NB_RETURN_AGG: ${NB_RETURN_AGG:-true}
-          NB_API_PORT: 8000
-          NB_API_ALLOWED_ORIGINS: ${NB_NAPI_ALLOWED_ORIGINS}
-          NB_ENABLE_AUTH: ${NB_ENABLE_AUTH:-false}
-          NB_QUERY_CLIENT_ID: ${NB_QUERY_CLIENT_ID}
-          VIRTUAL_HOST: myservice1.myinstitute.org # (1)!
-          LETSENCRYPT_HOST: myservice1.myinstitute.org # (2)!
-          VIRTUAL_PORT: 8000
-        volumes:
-          - "./scripts/api_entrypoint.sh:/usr/src/api_entrypoint.sh"
-        entrypoint:
-          - "/usr/src/api_entrypoint.sh"
+          api:
+            image: "neurobagel/api:${NB_NAPI_TAG:-latest}"
+            profiles:
+              - "local_node"
+              - "full_stack"
+            ports:
+              - "${NB_NAPI_PORT_HOST:-8000}:8000"
+            environment:
+              NB_GRAPH_USERNAME: ${NB_GRAPH_USERNAME}
+              NB_GRAPH_ADDRESS: graph
+              NB_GRAPH_PORT: 7200
+              NB_GRAPH_DB: ${NB_GRAPH_DB:-repositories/my_db}
+              NB_RETURN_AGG: ${NB_RETURN_AGG:-true}
+              NB_API_PORT: 8000
+              NB_API_ALLOWED_ORIGINS: ${NB_NAPI_ALLOWED_ORIGINS}
+              NB_ENABLE_AUTH: ${NB_ENABLE_AUTH:-false}
+              NB_QUERY_CLIENT_ID: ${NB_QUERY_CLIENT_ID}
+              VIRTUAL_HOST: myservice1.myinstitute.org
+              LETSENCRYPT_HOST: myservice1.myinstitute.org
+              VIRTUAL_PORT: 8000
+            volumes:
+              - "./scripts/api_entrypoint.sh:/usr/src/api_entrypoint.sh"
+            entrypoint:
+              - "/usr/src/api_entrypoint.sh"
+            secrets:
+              - db_user_password
+
+          graph:
+            image: "ontotext/graphdb:10.3.1"
+            profiles:
+              - "local_node"
+              - "full_stack"
+            volumes:
+              - "graphdb_home:/opt/graphdb/home"
+              - "./scripts:/usr/src/neurobagel/scripts"
+              - "./vocab:/usr/src/neurobagel/vocab"
+              - "${LOCAL_GRAPH_DATA:-./data}:/data"
+            ports:
+              - "${NB_GRAPH_PORT_HOST:-7200}:7200"
+            environment:
+              NB_GRAPH_USERNAME: ${NB_GRAPH_USERNAME}
+              NB_GRAPH_PORT: 7200
+              NB_GRAPH_DB: ${NB_GRAPH_DB:-repositories/my_db}
+            entrypoint:
+              - "/usr/src/neurobagel/scripts/setup.sh"
+            working_dir: "/usr/src/neurobagel/scripts"
+            secrets:
+              - db_admin_password
+              - db_user_password
+
+          federation:
+            image: "neurobagel/federation_api:${NB_FAPI_TAG:-latest}"
+            profiles:
+              - "local_federation"
+              - "full_stack"
+            ports:
+              - "${NB_FAPI_PORT_HOST:-8080}:8000"
+            volumes:
+              - "./local_nb_nodes.json:/usr/src/local_nb_nodes.json:ro"
+            environment:
+              NB_API_PORT: 8000
+              NB_FEDERATE_REMOTE_PUBLIC_NODES: ${NB_FEDERATE_REMOTE_PUBLIC_NODES:-True}
+              NB_ENABLE_AUTH: ${NB_ENABLE_AUTH:-false}
+              NB_QUERY_CLIENT_ID: ${NB_QUERY_CLIENT_ID}
+              VIRTUAL_HOST: myservice2.myinstitute.org
+              LETSENCRYPT_HOST: myservice2.myinstitute.org
+              VIRTUAL_PORT: 8000
+
+          query_federation:
+            image: "neurobagel/query_tool:${NB_QUERY_TAG:-latest}"
+            profiles:
+              - "local_federation"
+              - "full_stack"
+            ports:
+              - "${NB_QUERY_PORT_HOST:-3000}:5173"
+            environment:
+              NB_API_QUERY_URL: ${NB_API_QUERY_URL}
+              NB_QUERY_APP_BASE_PATH: ${NB_QUERY_APP_BASE_PATH:-/}
+              NB_ENABLE_AUTH: ${NB_ENABLE_AUTH:-false}
+              NB_QUERY_CLIENT_ID: ${NB_QUERY_CLIENT_ID}
+              VIRTUAL_HOST: myservice3.myinstitute.org
+              LETSENCRYPT_HOST: myservice3.myinstitute.org
+              VIRTUAL_PORT: 5173
+
+          nginx-proxy:
+            image: nginxproxy/nginx-proxy
+            container_name: nginx-proxy
+            ports:
+              - "80:80"
+              - "443:443"
+            volumes:
+              - ./config/nginx/reverse_proxy.conf:/etc/nginx/conf.d/reverse_proxy.conf
+              - vhost:/etc/nginx/vhost.d
+              - html:/usr/share/nginx/html
+              - certs:/etc/nginx/certs:ro
+              - /var/run/docker.sock:/tmp/docker.sock:ro
+
+          acme-companion:
+            image: nginxproxy/acme-companion
+            container_name: nginx-proxy-acme
+            volumes_from:
+              - nginx-proxy
+            volumes:
+              - certs:/etc/nginx/certs:rw
+              - acme:/etc/acme.sh
+              - /var/run/docker.sock:/var/run/docker.sock:ro
+
         secrets:
-          - db_user_password
+          db_admin_password:
+            file: ${NB_GRAPH_SECRETS_PATH:-./secrets}/NB_GRAPH_ADMIN_PASSWORD.txt
+          db_user_password:
+            file: ${NB_GRAPH_SECRETS_PATH:-./secrets}/NB_GRAPH_PASSWORD.txt
 
-      graph:
-        image: "ontotext/graphdb:10.3.1"
-        profiles:
-          - "local_node"
-          - "full_stack"
         volumes:
-          - "graphdb_home:/opt/graphdb/home"
-          - "./scripts:/usr/src/neurobagel/scripts"
-          - "./vocab:/usr/src/neurobagel/vocab"
-          - "${LOCAL_GRAPH_DATA:-./data}:/data"
-        ports:
-          - "${NB_GRAPH_PORT_HOST:-7200}:7200"
-        environment:
-          NB_GRAPH_USERNAME: ${NB_GRAPH_USERNAME}
-          NB_GRAPH_PORT: 7200
-          NB_GRAPH_DB: ${NB_GRAPH_DB:-repositories/my_db}
-        entrypoint:
-          - "/usr/src/neurobagel/scripts/setup.sh"
-        working_dir: "/usr/src/neurobagel/scripts"
+          graphdb_home:
+          vhost:
+          html:
+          certs:
+          acme:
+        ```
+
+    === "Caddy (`docker-compose.yml`)"
+        ```yaml
+        services:
+
+          api:
+            image: "neurobagel/api:${NB_NAPI_TAG:-latest}"
+            profiles:
+              - "local_node"
+              - "full_stack"
+            ports:
+              - "${NB_NAPI_PORT_HOST:-8000}:8000"
+            environment:
+              NB_GRAPH_USERNAME: ${NB_GRAPH_USERNAME}
+              NB_GRAPH_ADDRESS: graph
+              NB_GRAPH_PORT: 7200
+              NB_GRAPH_DB: ${NB_GRAPH_DB:-repositories/my_db}
+              NB_RETURN_AGG: ${NB_RETURN_AGG:-true}
+              NB_API_PORT: 8000
+              NB_API_ALLOWED_ORIGINS: ${NB_NAPI_ALLOWED_ORIGINS}
+              NB_ENABLE_AUTH: ${NB_ENABLE_AUTH:-false}
+              NB_QUERY_CLIENT_ID: ${NB_QUERY_CLIENT_ID}
+            volumes:
+              - "./scripts/api_entrypoint.sh:/usr/src/api_entrypoint.sh"
+            entrypoint:
+              - "/usr/src/api_entrypoint.sh"
+            secrets:
+              - db_user_password
+
+          graph:
+            image: "ontotext/graphdb:10.3.1"
+            profiles:
+              - "local_node"
+              - "full_stack"
+            volumes:
+              - "graphdb_home:/opt/graphdb/home"
+              - "./scripts:/usr/src/neurobagel/scripts"
+              - "./vocab:/usr/src/neurobagel/vocab"
+              - "${LOCAL_GRAPH_DATA:-./data}:/data"
+            ports:
+              - "${NB_GRAPH_PORT_HOST:-7200}:7200"
+            environment:
+              NB_GRAPH_USERNAME: ${NB_GRAPH_USERNAME}
+              NB_GRAPH_PORT: 7200
+              NB_GRAPH_DB: ${NB_GRAPH_DB:-repositories/my_db}
+            entrypoint:
+              - "/usr/src/neurobagel/scripts/setup.sh"
+            working_dir: "/usr/src/neurobagel/scripts"
+            secrets:
+              - db_admin_password
+              - db_user_password
+
+          federation:
+            image: "neurobagel/federation_api:${NB_FAPI_TAG:-latest}"
+            profiles:
+              - "local_federation"
+              - "full_stack"
+            ports:
+              - "${NB_FAPI_PORT_HOST:-8080}:8000"
+            volumes:
+              - "./local_nb_nodes.json:/usr/src/local_nb_nodes.json:ro"
+            environment:
+              NB_API_PORT: 8000
+              NB_FEDERATE_REMOTE_PUBLIC_NODES: ${NB_FEDERATE_REMOTE_PUBLIC_NODES:-True}
+              NB_ENABLE_AUTH: ${NB_ENABLE_AUTH:-false}
+              NB_QUERY_CLIENT_ID: ${NB_QUERY_CLIENT_ID}
+
+          query_federation:
+            image: "neurobagel/query_tool:${NB_QUERY_TAG:-latest}"
+            profiles:
+              - "local_federation"
+              - "full_stack"
+            ports:
+              - "${NB_QUERY_PORT_HOST:-3000}:5173"
+            environment:
+              NB_API_QUERY_URL: ${NB_API_QUERY_URL}
+              NB_QUERY_APP_BASE_PATH: ${NB_QUERY_APP_BASE_PATH:-/}
+              NB_ENABLE_AUTH: ${NB_ENABLE_AUTH:-false}
+              NB_QUERY_CLIENT_ID: ${NB_QUERY_CLIENT_ID}
+
+          caddy:
+            image: caddy:latest
+            container_name: caddy
+            ports:
+              - "80:80"
+              - "443:443"
+            volumes:
+              - ./Caddyfile:/etc/caddy/Caddyfile
+              - caddy_data:/data
+              - caddy_config:/config
+
         secrets:
-          - db_admin_password
-          - db_user_password
+          db_admin_password:
+            file: ${NB_GRAPH_SECRETS_PATH:-./secrets}/NB_GRAPH_ADMIN_PASSWORD.txt
+          db_user_password:
+            file: ${NB_GRAPH_SECRETS_PATH:-./secrets}/NB_GRAPH_PASSWORD.txt
 
-      federation:
-        image: "neurobagel/federation_api:${NB_FAPI_TAG:-latest}"
-        profiles:
-          - "local_federation"
-          - "full_stack"
-        ports:
-          - "${NB_FAPI_PORT_HOST:-8080}:8000"
         volumes:
-          - "./local_nb_nodes.json:/usr/src/local_nb_nodes.json:ro"
-        environment:
-          NB_API_PORT: 8000
-          NB_FEDERATE_REMOTE_PUBLIC_NODES: ${NB_FEDERATE_REMOTE_PUBLIC_NODES:-True}
-          NB_ENABLE_AUTH: ${NB_ENABLE_AUTH:-false}
-          NB_QUERY_CLIENT_ID: ${NB_QUERY_CLIENT_ID}
-          VIRTUAL_HOST: myservice2.myinstitute.org # (3)!
-          LETSENCRYPT_HOST: myservice2.myinstitute.org # (4)!
-          VIRTUAL_PORT: 8000
+          graphdb_home:
+          caddy_data:
+          caddy_config:
+        ```
 
-      query_federation:
-        image: "neurobagel/query_tool:${NB_QUERY_TAG:-latest}"
-        profiles:
-          - "local_federation"
-          - "full_stack"
-        ports:
-          - "${NB_QUERY_PORT_HOST:-3000}:5173"
-        environment:
-          NB_API_QUERY_URL: ${NB_API_QUERY_URL}
-          NB_QUERY_APP_BASE_PATH: ${NB_QUERY_APP_BASE_PATH:-/}
-          NB_ENABLE_AUTH: ${NB_ENABLE_AUTH:-false}
-          NB_QUERY_CLIENT_ID: ${NB_QUERY_CLIENT_ID}
-          VIRTUAL_HOST: myservice3.myinstitute.org # (5)!
-          LETSENCRYPT_HOST: myservice3.myinstitute.org # (6)!
-          VIRTUAL_PORT: 5173
+        ### Reverse Proxy Configuration with Caddy
 
-      nginx-proxy:
-        image: nginxproxy/nginx-proxy
-        container_name: nginx-proxy
-        ports:
-          - "80:80"
-          - "443:443"
-        volumes:
-          - ./config/nginx/reverse_proxy.conf:/etc/nginx/conf.d/reverse_proxy.conf
-          - vhost:/etc/nginx/vhost.d
-          - html:/usr/share/nginx/html
-          - certs:/etc/nginx/certs:ro
-          - /var/run/docker.sock:/tmp/docker.sock:ro
+        ```caddyfile
+        myservice1.myinstitute.org {
+            reverse_proxy api:8000
+        }
 
-      acme-companion:
-        image: nginxproxy/acme-companion
-        container_name: nginx-proxy-acme
-        volumes_from:
-          - nginx-proxy
-        volumes:
-          - certs:/etc/nginx/certs:rw
-          - acme:/etc/acme.sh
-          - /var/run/docker.sock:/var/run/docker.sock:ro
+        myservice2.myinstitute.org {
+            reverse_proxy federation:8000
+        }
 
-    secrets:
-      db_admin_password:
-        file: ${NB_GRAPH_SECRETS_PATH:-./secrets}/NB_GRAPH_ADMIN_PASSWORD.txt
-      db_user_password:
-        file: ${NB_GRAPH_SECRETS_PATH:-./secrets}/NB_GRAPH_PASSWORD.txt
-
-    volumes:
-      graphdb_home:
-      vhost:
-      html:
-      certs:
-      acme:
-    ```
-
-    1. Replace with your custom domain
-    2. Replace with your custom domain (should be same as `VIRTUAL_HOST` for this service)
-    3. Replace with your custom domain
-    4. Replace with your custom domain (should be same as `VIRTUAL_HOST` for this service)
-    5. Replace with your custom domain
-    6. Replace with your custom domain (should be same as `VIRTUAL_HOST` for this service)
-
+        myservice3.myinstitute.org {
+            reverse_proxy query_federation:5173
+        }
+        ```
 
 ## Manually setting up a Neurobagel graph backend
 

--- a/docs/user_guide/config.md
+++ b/docs/user_guide/config.md
@@ -195,30 +195,25 @@ This file adds:
 - [acme-companion](https://github.com/nginx-proxy/acme-companion) to automatically create and renew SSL certificates for NGINX proxied service containers
 
 
-!!! warning "Community Contribution"
-        
-    **Disclaimer:** This example `docker-compose.yml` is a community-contributed resource and is not officially maintained or supported by the Neurobagel team.
+**Example `docker-compose.yml` with Reverse Proxy**
 
-    **Compatibility Note:** This example has been tested with version `v0.4.1` of the [Neurobagel deployment recipes](https://github.com/neurobagel/recipes). Ensure you are using the same or a compatible version for optimal results.
+To use this file:
 
-??? abstract "Example `docker-compose.yml` with reverse proxy"
-    To use this file:
+1. If you haven't already, follow the [steps](getting_started.md#the-neurobagel-node-deployment-recipe) to clone and minimally configure the services in the [Neurobagel deployment recipe](https://github.com/neurobagel/recipes).
+2. Replace the default `docker-compose.yml` in the `recipes` directory with the appropriate file from below.
+3. Select the reverse proxy recipe you prefer:
 
-    1. If you haven't already, follow the [steps](getting_started.md#the-neurobagel-node-deployment-recipe) to clone and minimally configure the services in the [Neurobagel deployment recipe](https://github.com/neurobagel/recipes).
-    2. Replace the default `docker-compose.yml` in the `recipes` directory with the below file.
-    3. Open the file, and edit the values of `VIRTUAL_HOST` and `LETSENCRYPT_HOST` to the domains your proxied services will use.
-       - This assumes you have already registered your domain(s) with a DNS provider and configured the DNS settings to resolve correctly to your host machine.
-    4. From the root of the `recipes` directory, run:
-        ```bash
-        docker compose up -d
-        ```
-        (or, see [here](#available-profiles) to launch a non-default service profile).
-    5. Ensure that ports 80 and 443 are open on the host machine where your Docker Compose stack is running.
+=== "NGINX"
+    ??? abstract "NGINX Reverse Proxy Configuration"
+        **To use this file:**
 
-    === "NGINX(`docker-compose.yml`)"
+        - Open the file and edit the values of `VIRTUAL_HOST` and `LETSENCRYPT_HOST` to the domains your proxied services will use.
+
+        - This assumes you have already registered your domain(s) with a DNS provider and configured the DNS settings to resolve correctly to your host machine.
+
+        **`docker-compose.yml`:**
         ```yaml
-        services:
-
+         services:
           api:
             image: "neurobagel/api:${NB_NAPI_TAG:-latest}"
             profiles:
@@ -236,8 +231,8 @@ This file adds:
               NB_API_ALLOWED_ORIGINS: ${NB_NAPI_ALLOWED_ORIGINS}
               NB_ENABLE_AUTH: ${NB_ENABLE_AUTH:-false}
               NB_QUERY_CLIENT_ID: ${NB_QUERY_CLIENT_ID}
-              VIRTUAL_HOST: myservice1.myinstitute.org
-              LETSENCRYPT_HOST: myservice1.myinstitute.org
+              VIRTUAL_HOST: myservice1.myinstitute.org 
+              LETSENCRYPT_HOST: myservice1.myinstitute.org 
               VIRTUAL_PORT: 8000
             volumes:
               - "./scripts/api_entrypoint.sh:/usr/src/api_entrypoint.sh"
@@ -340,10 +335,16 @@ This file adds:
           acme:
         ```
 
-    === "Caddy (`docker-compose.yml`)"
+=== "Caddy"
+    !!! warning "Community Contribution"
+        **Disclaimer:** This example `docker-compose.yml` is a community-contributed resource and is not officially maintained or supported by the Neurobagel team.
+        
+        **Compatibility Note:** This example has been tested with version `v0.4.1` of the [Neurobagel deployment recipes](https://github.com/neurobagel/recipes). Ensure you are using the same or a compatible version for optimal results.
+    
+    ??? abstract "Caddy Reverse Proxy Configuration"
+        **`docker-compose.yml`:**
         ```yaml
         services:
-
           api:
             image: "neurobagel/api:${NB_NAPI_TAG:-latest}"
             profiles:
@@ -441,22 +442,31 @@ This file adds:
           caddy_data:
           caddy_config:
         ```
-
-        ### Reverse Proxy Configuration with Caddy
-
+    
+        **Example `Caddyfile`:**
         ```caddyfile
         myservice1.myinstitute.org {
             reverse_proxy api:8000
         }
-
+        
         myservice2.myinstitute.org {
             reverse_proxy federation:8000
         }
-
+        
         myservice3.myinstitute.org {
             reverse_proxy query_federation:5173
         }
         ```
+
+4. Running the Stack
+
+- After selecting your reverse proxy configuration and updating the required values, start the services by running:
+
+    ```bash
+    docker compose up -d
+    ```
+
+5. Make sure that ports 80 and 443 are open on the host machine where your Docker Compose stack is running.
 
 ## Manually setting up a Neurobagel graph backend
 


### PR DESCRIPTION
<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #263 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Added `docker-compose.yml` to configure caddy as a reverse proxy.
- Added an example `Caddyfile`.

<!-- To be checked off by reviewers -->
## Checklist
_Please leave checkboxes empty for PR reviewers_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`) _see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING/#pull-request-guidelines) for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Checks pass
