### PR TITLE
[ENH] Add `nb:FromRange` to list of available age transformations

### DIFF
--- a/docs/data_models/dictionaries.md
+++ b/docs/data_models/dictionaries.md
@@ -271,19 +271,19 @@ this is a Neurobagel common data element.
 ### Age
 Neurobagel has a common data element for `"Age"` describing a continuous column. 
 To ensure age values are represented as floats in Neurobagel graphs, 
-Neurobagel encodes the relevant "heuristic" describing the value format for a given age column. 
-This heuristic, stored in the `Transformation` annotation (required for continuous columns describing age), 
-maps internally to a specific transformation that is used to convert the values to floats.
+Neurobagel encodes the relevant "transformation" based on the format of values in a given age column. 
+This is stored in the `Transformation` annotation (required for continuous columns describing age) and maps internally to a specific transformation that is used to convert the values to floats.
 
-Possible heuristics: 
+Possible transformations: 
 
 | TermURL | Label | Example |
 | ----- | ----- | ----- |
-| `nb:FromFloat` | float value | `31.5`
-| `nb:FromInt` | integer value | `31`
-| `nb:FromEuro` | european decimal value | `31,5`
-| `nb:FromBounded` | bounded value | `30+`
-| `nb:FromISO8061` | period of time defined according to the ISO8601 standard | `31Y6M`
+| `nb:FromFloat` | float value | `31.5` |
+| `nb:FromInt` | integer value | `31` |
+| `nb:FromEuro` | european decimal value | `31,5` |
+| `nb:FromBounded` | bounded value | `30+` |
+| `nb:FromRange` | a range between a minimum and maximum value | `30-35` |
+| `nb:FromISO8061` | period of time defined according to the ISO8601 standard | `31Y6M` |
 
 
 ```json hl_lines="9-12"


### PR DESCRIPTION
<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Related to https://github.com/neurobagel/bagel-cli/pull/437

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Remove use of word "heuristic" from description of age column to reduce confusion/complexity around terms

<!-- To be checked off by reviewers -->
## Checklist
_Please leave checkboxes empty for PR reviewers_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`) _see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING/#pull-request-guidelines) for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Checks pass
