### PR TITLE
[ENH] Add check for redirects

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,3 +23,4 @@ _Please leave checkboxes empty for PR reviewers_
 - [ ] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`) _see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING/#pull-request-guidelines) for more info)_
 - [ ] PR links to GitHub issue with mention `Closes #XXXX`
 - [ ] Checks pass
+- [ ] If an existing page was renamed or deleted, redirects have been added to [the `mkdocs.yml` config](https://github.com/neurobagel/documentation/blob/main/mkdocs.yml)


### PR DESCRIPTION
From #302 we have the ability to make redirects. We should make sure not to forget this during PR review

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->


<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

-
-

<!-- To be checked off by reviewers -->
## Checklist
_Please leave checkboxes empty for PR reviewers_

- [ ] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`) _see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING/#pull-request-guidelines) for more info)_
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Checks pass
