### PR TITLE
[ENH] Update data dictionary snippets to latest schema and remove deprecated `FromInt` format

### DIFF
--- a/docs/data_models/dictionaries.md
+++ b/docs/data_models/dictionaries.md
@@ -56,7 +56,7 @@ And here is the same data dictionary augmented with Neurobagel annotations:
       },
       "Format": {
         "TermURL": "nb:FromFloat",
-        "Label": "Integer"
+        "Label": "Float"
       },
       "VariableType": "Continuous"
     }


### PR DESCRIPTION
<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #321

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Remove `FromInt` from accepted formats
- Remove `Identifies` key and add `VariableType` key to example annotation snippets
- Use CURIEs everywhere in data dictionary snippets

<!-- To be checked off by reviewers -->
## Checklist
_Please leave checkboxes empty for PR reviewers_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`) _see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING/#pull-request-guidelines) for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Checks pass
- [ ] If an existing page was renamed or deleted, redirects have been added to [the `mkdocs.yml` config](https://github.com/neurobagel/documentation/blob/main/mkdocs.yml)
