### PR TITLE
Add Neurobagel service status link to homepage

### DIFF
--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -25,6 +25,16 @@
                                 Neurobagel allows you to connect a local neuroimaging dataset with others in a decentralized framework
                                 using linked data principles.
                             </p>
+                            <div class="mt-6 flex justify-center lg:justify-start">
+                                <a
+                                    href="https://status.neurobagel.org/"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="inline-flex items-center gap-2 px-5 py-2 text-sm font-semibold text-white bg-emerald-500 rounded-full transition-all duration-200 shadow-md hover:bg-emerald-400 hover:scale-105 hover:shadow-xl"
+                                >
+                                    Service Status →
+                                </a>
+                            </div>
                         </div>
                         <div class="flex flex-col items-center justify-center gap-3 mt-10 lg:flex-row lg:justify-start">
                             <a href="/user_guide/getting_started"


### PR DESCRIPTION
<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #360 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:
- Added a visible **Service Status** link on the homepage hero section that directs users to https://status.neurobagel.org/.
- Styled the link to match existing homepage typography and maintain visual consistency with current UI elements.
- Improves discoverability of Neurobagel service uptime and monitoring information for users.

## This is how it looks with these changes

https://github.com/user-attachments/assets/47a66e75-1c5b-4638-ae2c-e887f8f581ad


<!-- To be checked off by reviewers -->
## Checklist
_Please leave checkboxes empty for PR reviewers_

- [ ] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`) _see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING/#pull-request-guidelines) for more info)_
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Checks pass
- [ ] If an existing page was renamed or deleted, redirects have been added to [the `mkdocs.yml` config](https://github.com/neurobagel/documentation/blob/main/mkdocs.yml)
