### PR TITLE
[ENH] Add system dependency instructions to Neurobagel CLI documentation

### DIFF
--- a/docs/user_guide/cli.md
+++ b/docs/user_guide/cli.md
@@ -3,6 +3,51 @@
 The Neurobagel CLI is a command-line tool that processes a Neurobagel-annotated dataset and produces harmonized subject-level phenotypic and imaging attributes. 
 The resulting harmonized data can be directly integrated into a Neurobagel graph store.
 
+## System dependencies
+
+Before installing or running the Neurobagel CLI, ensure the following tools are available on your system.
+
+!!! tip
+    Choose the dependency instructions that match how you plan to run the CLI (native Python, Docker, or Apptainer).
+
+=== "Python"
+
+    The CLI requires **Python 3.10 or later**.
+
+    Install Python: [https://www.python.org/downloads/](https://www.python.org/downloads/)
+
+    Verify installation:
+
+    ```bash
+    python --version
+    ```
+
+=== "Docker"
+
+    Required if you plan to run the CLI using containers.
+
+    Install Docker: [https://docs.docker.com/get-docker/](https://docs.docker.com/get-docker/)
+
+    Verify installation:
+
+    ```bash
+    docker --version
+    ```
+
+=== "Apptainer"
+
+    Optional container runtime supported by the Neurobagel CLI.
+
+    Installation instructions:
+    [https://apptainer.org/docs/admin/main/installation.html](https://apptainer.org/docs/admin/main/installation.html)
+
+    Verify installation:
+
+    ```bash
+    apptainer --version
+    ```
+
+
 ## Installation
 
 === "Python"


### PR DESCRIPTION
<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #338 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Added a new **System dependencies** section to the Neurobagel CLI docs.
- Introduce tabbed instructions for Python, Docker, and Apptainer prerequisites.
- Improve readability by guiding users before installation.
- Align formatting with existing MkDocs tab/admonition patterns.

This change helps prevent confusion if users attempt installation without required runtimes installed.

## How it looks

https://github.com/user-attachments/assets/b0b4b4a8-a8d5-4370-9230-d5a4a537a43d


<!-- To be checked off by reviewers -->
## Checklist
_Please leave checkboxes empty for PR reviewers_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`) _see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING/#pull-request-guidelines) for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Checks pass
- [ ] If an existing page was renamed or deleted, redirects have been added to [the `mkdocs.yml` config](https://github.com/neurobagel/documentation/blob/main/mkdocs.yml)
