### PR TITLE
[FIX] Fix typos, grammar, and formatting across documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Note: Both relative and absolute paths can be used to specify files or directori
 
 ## Build
 
-To spin up the side locally while you edit it, run:
+To spin up the site locally while you edit it, run:
 
 `mkdocs serve`
 
@@ -77,7 +77,7 @@ pre-commit install
 
 After this the style guide will be enforced every time you commit:
 some pre-commit 'hooks' will try to fix some of the errors they find,
-so you may have to restaage your file before committing.
+so you may have to restage your file before committing.
 
 For markdownlint, you can also use
 the [VS-code extension](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)

--- a/docs/contributing/team.md
+++ b/docs/contributing/team.md
@@ -19,7 +19,7 @@ Neurobagel is a project originating from the [ORIGAMI Lab](https://neurodatascie
   </tr>
   <tr>
     <td align="center"><a href="https://github.com/Remi-Gau"><img src="../../overrides/assets/img/remi_gau.jpeg" width="100px;" alt=""/><br /><sub><b>Remi Gau</b></sub></td>
-    <td align="center"><a href="https://www.mcgill.ca/neuro/jean-baptiste-poline-phd"><img src="../../overrides/assets/img/jb.jpg" width="100px;" alt=""/><br /><sub><b>Jean-Baptise Poline</b></sub></a><br/>🧑‍🔬</td>
+    <td align="center"><a href="https://www.mcgill.ca/neuro/jean-baptiste-poline-phd"><img src="../../overrides/assets/img/jb.jpg" width="100px;" alt=""/><br /><sub><b>Jean-Baptiste Poline</b></sub></a><br/>🧑‍🔬</td>
   </tr>
 </table>
 

--- a/docs/data_models/dictionaries.md
+++ b/docs/data_models/dictionaries.md
@@ -359,7 +359,7 @@ contain any `MissingValues`.
 
 For the above example, this would be:
 
-| particpant_id | updrs_1 | updrs_2 |
+| participant_id | updrs_1 | updrs_2 |
 | ------------- | ------- | ------- |
 | sub-01 | 2 | |
 | sub-02 | 1 | 1 |
@@ -367,7 +367,7 @@ For the above example, this would be:
 
 Therefore:
 
-| particpant_id | updrs_available |
+| participant_id | updrs_available |
 | ------------- | --------------- |
 | sub-01 | True |
 | sub-02 | True |

--- a/docs/data_models/graph_data.md
+++ b/docs/data_models/graph_data.md
@@ -2,7 +2,7 @@
 
 ## Overview
 Using the Neurobagel CLI (see also the [section on the CLI](../user_guide/cli.md)),
-a Neurobagel data dictionary (`.json`) for a dataset can be processed together with the corresponding tabular data (`.tsv`) and BIDS dataset (if available) to generate subject-level [linked data](https://www.w3.org/wiki/LinkedData) that can be encoded in a knowledge graph.
+a Neurobagel data dictionary (`.json`) for a dataset can be processed together with the corresponding tabular data (`.tsv`) and BIDS dataset (if available) to generate subject-level [linked data](https://en.wikipedia.org/wiki/Linked_data) that can be encoded in a knowledge graph.
 The Neurobagel graph-ready data are stored in [JSON-LD](https://json-ld.org/) format (`.jsonld`),
 and include a representation of each subject's harmonized phenotypic properties and imaging metadata.
 

--- a/docs/data_models/graph_data.md
+++ b/docs/data_models/graph_data.md
@@ -2,7 +2,7 @@
 
 ## Overview
 Using the Neurobagel CLI (see also the [section on the CLI](../user_guide/cli.md)),
-a Neurobagel data dictionary (`.json`) for a dataset can be processed together with the corresponding tabular data (`.tsv`) and BIDS dataset (if available) to generate subject-level [linked data](https://en.wikipedia.org/wiki/Linked_data) that can be encoded in a knowledge graph.
+a Neurobagel data dictionary (`.json`) for a dataset can be processed together with the corresponding tabular data (`.tsv`) and BIDS dataset (if available) to generate subject-level [linked data](https://www.w3.org/wiki/LinkedData) that can be encoded in a knowledge graph.
 The Neurobagel graph-ready data are stored in [JSON-LD](https://json-ld.org/) format (`.jsonld`),
 and include a representation of each subject's harmonized phenotypic properties and imaging metadata.
 

--- a/docs/data_models/term_naming_standards.md
+++ b/docs/data_models/term_naming_standards.md
@@ -10,7 +10,7 @@
 - Names should adhere to camelCase (uses capitalized words except for the first word/letter)
 - Should be a compound of:
     - a verb relevant to the property (e.g., **has**Age, **is**SubjectGroup)
-    - the [range](https://www.w3.org/TR/owl-ref/#range-def) of the property, (e.g.,has**Diagnosis** points to a Diagnosis object)
+    - the [range](https://www.w3.org/TR/owl-ref/#range-def) of the property, (e.g., has**Diagnosis** points to a Diagnosis object)
 
 What this might look like in semantic triples:
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -85,7 +85,7 @@ This glossary compiles some key terms used in the Neurobagel documentation and d
 ### Graph database
 **Used interchangeably with**: knowledge graph store, graph store, graph
 
-:   A type of database, in the same way that a relational databases is a type of database.
+:   A type of database, in the same way that a relational database is a type of database.
     The main distinguishing feature of graph databases is that they
     represent entities as nodes in a graph,
     and relationships between entities as edges between these nodes.

--- a/docs/user_guide/api.md
+++ b/docs/user_guide/api.md
@@ -5,7 +5,7 @@
 Neurobagel has two flavours of APIs that can be deployed: **node API** and **federation API**.
 
 - A [Neurobagel node API (n-API)](https://github.com/neurobagel/api) formulates SPARQL queries based on a set of user-defined parameters to a single connected graph database, and processes returned query results into a user-friendly format.
-- A [Neurobagel federation API (f-API)](https://github.com/neurobagel/federation-api) lets the user sends a single query to _each_ node API it is aware of, and collects and combines the decentralized responses into a single set of query results.
+- A [Neurobagel federation API (f-API)](https://github.com/neurobagel/federation-api) lets the user send a single query to _each_ node API it is aware of, and collects and combines the decentralized responses into a single set of query results.
 
 Neurobagel's query tool provides a GUI for querying one or more Neurobagel graphs by sending requests to a Neurobagel _federation API_ instance.
 However, HTTP requests can also be sent directly to any publicly accessible Neurobagel API (node or federation).

--- a/docs/user_guide/data_prep.md
+++ b/docs/user_guide/data_prep.md
@@ -8,7 +8,7 @@
 To use the Neurobagel annotation tool,
 you must prepare the tabular data for your dataset as a single tab-separated values (`.tsv`) file.
 
-Within Neurobagel, tabular (or phenotypic) data  refers to any demographic, clinical/behavioural, cognitive, or other non-imaging-derived data of participants
+Within Neurobagel, tabular (or phenotypic) data refers to any demographic, clinical/behavioural, cognitive, or other non-imaging-derived data of participants
 which are typically stored in a tabular format.
 
 ## Requirements for the phenotypic TSV

--- a/docs/user_guide/getting_started.md
+++ b/docs/user_guide/getting_started.md
@@ -84,7 +84,7 @@ Docker Compose recipe and template configuration files for setting up a local Ne
 
 !!! info "Production deployments require additional configuration"
 
-    This section provide a minimal configuration for launching Neurobagel
+    This section provides a minimal configuration for launching Neurobagel
     so you can get started quickly with trying out all services locally.
     In most cases, particularly when deploying Neurobagel for other users,
     additional configurations are necessary.

--- a/docs/user_guide/preparing_imaging_data.md
+++ b/docs/user_guide/preparing_imaging_data.md
@@ -8,6 +8,7 @@ If your dataset is already in [BIDS](https://bids-specification.readthedocs.io/e
 The BIDS metadata table lists each subject's available imaging files and modality information, using [BIDS](https://bids-specification.readthedocs.io/en/stable/) naming conventions, in the format shown below.
 
 ## Example BIDS metadata table
+
 | sub | ses | suffix | path |
 | ---- | ---- | ---- | ---- |
 | sub-01 | ses-01 | T1w | /data/bids-examples/synthetic/sub-01/ses-01/anat/sub-01_ses-01_T1w.nii |


### PR DESCRIPTION
<!--
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->

<!--
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Fixed spelling mistakes in [README.md](cci:7://file:///c:/Users/dhanu/Desktop/neurobagel%20repo/documentation/README.md:0:0-0:0) ("side" to "site", "restaage" to "restage").
- Corrected spelling of "Jean-Baptiste" in the team grid in [docs/contributing/team.md](cci:7://file:///c:/Users/dhanu/Desktop/neurobagel%20repo/documentation/docs/contributing/team.md:0:0-0:0).
- Fixed the "particpant_id" typo to "participant_id" in [docs/data_models/dictionaries.md](cci:7://file:///c:/Users/dhanu/Desktop/neurobagel%20repo/documentation/docs/data_models/dictionaries.md:0:0-0:0).
- Added a missing space after "e.g.," in [docs/data_models/term_naming_standards.md](cci:7://file:///c:/Users/dhanu/Desktop/neurobagel%20repo/documentation/docs/data_models/term_naming_standards.md:0:0-0:0).
- Fixed subject-verb agreement in [docs/user_guide/api.md](cci:7://file:///c:/Users/dhanu/Desktop/neurobagel%20repo/documentation/docs/user_guide/api.md:0:0-0:0) ("sends" to "send").
- Removed an accidental double space in [docs/user_guide/data_prep.md](cci:7://file:///c:/Users/dhanu/Desktop/neurobagel%20repo/documentation/docs/user_guide/data_prep.md:0:0-0:0).
- Fixed subject-verb agreement in [docs/user_guide/getting_started.md](cci:7://file:///c:/Users/dhanu/Desktop/neurobagel%20repo/documentation/docs/user_guide/getting_started.md:0:0-0:0) ("provide" to "provides").

<!-- To be checked off by reviewers -->
## Checklist
_Please leave checkboxes empty for PR reviewers_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`) _see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING/#pull-request-guidelines) for more info)_
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Checks pass
- [ ] If an existing page was renamed or deleted, redirects have been added to [the `mkdocs.yml` config](https://github.com/neurobagel/documentation/blob/main/mkdocs.yml)
