### PR TITLE
[ENH] Generate glossary-style reference page for environment variables using a macro

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,9 @@ repos:
     rev: v0.47.0
     hooks:
     - id: markdownlint
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 26.1.0
+    hooks:
+      - id: black
+        args:
+          - --safe

--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ Each subdirectory can then itself contain a `.nav.yml` to organize the pages wit
 
 Note: Both relative and absolute paths can be used to specify files or directories in `.nav.yml`.
 
+## Updating the environment variables reference
+
+The environment variables reference is auto-rendered from the file `docs/includes/environment_variables.yaml` using a [macro](https://mkdocs-macros-plugin.readthedocs.io/en/latest/) stored in `docs/macros/main.py`.
+
+To update the metadata for a variable, directly edit the source yaml file.
+
+To update the formatting of the rendered markdown reference sections, edit the macro functions inside the macro module directly.
+
+Information on excluding markdown sections or pages from macro rendering can be found [here](https://mkdocs-macros-plugin.readthedocs.io/en/latest/rendering/#solutions).
+
 ## Build
 
 To spin up the side locally while you edit it, run:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ To update the metadata for a variable, directly edit the source yaml file.
 
 To update the formatting of the rendered markdown reference sections, edit the macro functions inside the macro module directly.
 
+**Variable ordering**: The order of variable sections is defined in the macro module.
+For a given `ini_section`, variables appear in the order they are defined in the yaml file.
+
 Information on excluding markdown sections or pages from macro rendering can be found [here](https://mkdocs-macros-plugin.readthedocs.io/en/latest/rendering/#solutions).
 
 ## Build

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -146,7 +146,7 @@ This glossary compiles some key terms used in the Neurobagel documentation and d
     for enabling or disabling experimental settings.
 
     For information on all available configuration options,
-    see the [Environment variables reference](user_guide/maintaining.md#environment-variables-reference).
+    see the [Environment variables reference](user_guide/environment_variables.md#local_graph_data).
 
 ### Node API
 **Used interchangeably with**: n-API

--- a/docs/includes/environment_variables.yaml
+++ b/docs/includes/environment_variables.yaml
@@ -1,0 +1,265 @@
+- name: NB_GRAPH_USERNAME
+  description: >-
+    Username to set for the graph database user.
+  default: DBUSER
+  ini_section: "service:graph"
+  deployment_profiles:
+    - quickstart
+    - node
+
+- name: NB_GRAPH_SECRETS_PATH
+  description: >-
+    Path to files containing the secure passwords to set for the admin user (NB_GRAPH_ADMIN_PASSWORD.txt) and graph database user (NB_GRAPH_PASSWORD.txt).
+  default: ./secrets
+  ini_section: "service:graph"
+  deployment_profiles:
+    - quickstart
+    - node
+
+- name: NB_GRAPH_DB
+  description: >-
+    Name for your your graph database, in the format `repositories/{database_name}`.
+  default: repositories/my_db
+  ini_section: "service:graph"
+  deployment_profiles:
+    - quickstart
+    - node
+
+- name: LOCAL_GRAPH_DATA
+  description: >-
+    Path on your filesystem to the JSONLD files you want to upload to the graph database.
+  default: ./data
+  ini_section: "service:graph"
+  deployment_profiles:
+    - quickstart
+    - node
+
+- name: NB_GRAPH_PORT_HOST
+  description: >-
+    Port number on the host machine to map the graph server container port to.
+  default: 7200
+  ini_section: "service:graph"
+  deployment_profiles:
+    - quickstart
+  testing_only: true
+
+- name: NB_GRAPH_MEMORY
+  description: >-
+    The maximum amount of memory that can be used by graph.
+    Equivalent to setting the `-Xmx` parameter on the JVM.
+    Value should be a number followed by a letter denoting the unit.
+  default: 2G
+  ini_section: "service:graph"
+  deployment_profiles:
+    - quickstart
+    - node
+
+- name: NB_NAPI_TAG
+  description: >-
+    Docker image tag for the Neurobagel node API.
+  default: latest
+  ini_section: "service:node-api"
+  deployment_profiles:
+    - quickstart
+    - node
+
+- name: NB_RETURN_AGG
+  description: >-
+    Whether to return only aggregate, dataset-level query results (excluding subject/session-level attributes).
+    One of [`true`, `false`]
+  default: true
+  ini_section: "service:node-api"
+  deployment_profiles:
+    - quickstart
+    - node
+
+- name: NB_MIN_CELL_SIZE
+  description: >-
+    Minimum number of matching subjects required for a dataset to be returned as a query match.
+    Datasets with matching subjects <= this number will be excluded from query results.
+  default: 0
+  ini_section: "service:node-api"
+  deployment_profiles:
+    - quickstart
+    - node
+
+- name: NB_NAPI_DOMAIN
+  description: >-
+    The domain name where the n-API will be hosted from.
+  default: ""
+  ini_section: "service:node-api"
+  deployment_profiles:
+    - node
+
+- name: NB_NAPI_BASE_PATH
+  description: >-
+    The URL path (path segment after the domain) where the node API should be served from.
+    If set to a custom value, must include a leading slash.
+  default: ""
+  ini_section: "service:node-api"
+  deployment_profiles:
+    - node
+
+- name: NB_NAPI_PORT_HOST
+  description: >-
+    Port number on the host machine to map the Neurobagel node API container port to.
+  default: "8000"
+  ini_section: "service:node-api"
+  deployment_profiles:
+    - quickstart
+  testing_only: true
+
+- name: NB_CONFIG
+  description: >-
+    Name of the Neurobagel community configuration to load, if the node uses a community's custom vocabularies.
+  default: Neurobagel
+  ini_section: "service:node-api"
+  deployment_profiles:
+    - quickstart
+    - node
+
+- name: NB_FAPI_TAG
+  description: >-
+    Docker image tag for the Neurobagel federation API.
+  default: latest
+  ini_section: "service:federation-api"
+  deployment_profiles:
+    - quickstart
+    - portal
+
+- name: NB_FEDERATE_REMOTE_PUBLIC_NODES
+  description: >-
+    If `true`, include public nodes in federation.
+    If `false`, only locally specified nodes in `local_nb_nodes.json` are queried.
+  default: true
+  ini_section: "service:federation-api"
+  deployment_profiles:
+    - quickstart
+    - portal
+
+- name: NB_FAPI_DOMAIN
+  description: >-
+    The domain name where the f-API will be hosted from.
+  default: ""
+  ini_section: "service:federation-api"
+  deployment_profiles:
+    - portal
+
+- name: NB_FAPI_BASE_PATH
+  description: >-
+    The URL path (path segment after the domain) where the federation API should be served from.
+    If set to a custom value, must include a leading slash.
+  default: ""
+  ini_section: "service:federation-api"
+  deployment_profiles:
+    - portal
+
+- name: NB_FAPI_PORT_HOST
+  description: >-
+    Port number on the host machine to map the Neurobagel federation API container port to.
+  default: 8080
+  ini_section: "service:federation-api"
+  deployment_profiles:
+    - quickstart
+  testing_only: true
+
+- name: NB_QUERY_TAG
+  description: >-
+    Docker image tag for the query tool.
+  default: latest
+  ini_section: "service:query"
+  deployment_profiles:
+    - quickstart
+    - portal
+
+- name: NB_API_QUERY_URL
+  description: >-
+    URL of the Neurobagel f-API that the query tool will send its requests to.
+    The query tool sends requests from a user's machine, so ensure the API URL is provided *as a user would access it from their own machine*.
+    Ignored in a production deployment.
+  default: http://localhost:8080
+  ini_section: "service:query"
+  deployment_profiles:
+    - quickstart
+  testing_only: true
+
+- name: NB_QUERY_DOMAIN
+  description: >-
+    The domain name where the query tool will be hosted from.
+  default: ""
+  ini_section: "service:query"
+  deployment_profiles:
+    - portal
+
+- name: NB_QUERY_APP_BASE_PATH
+  description: >-
+    The URL path (path segment after the domain) where the query tool should be served from.
+    Must include a leading slash.
+  default: /
+  ini_section: "service:query"
+  deployment_profiles:
+    - portal
+
+- name: NB_QUERY_PORT_HOST
+  description: >-
+    Port number on the host machine to map the query tool container port to.
+  default: 3000
+  ini_section: "service:query"
+  deployment_profiles:
+    - quickstart
+  testing_only: true
+
+- name: NB_QUERY_HEADER_SCRIPT
+  description: >-
+    Custom script to add to the header section of the query tool site, such as for a GDPR-aware analytics tool.
+  default: null
+  ini_section: "service:query"
+  developer_only: true  # double check
+  deployment_profiles:
+    - quickstart
+    - portal
+
+- name: COMPOSE_PROFILES
+  description: >-
+    Selects the production launch profile to use: `node` or `portal`.
+    If not specified, will default to a testing deployment.
+    See the [production deployment documentation](https://neurobagel.org/user_guide/production_deployment) for details.
+  default: N/A
+  ini_section: "compose"
+  deployment_profiles:
+    - node
+    - portal
+
+- name: COMPOSE_PROJECT_NAME
+  description: >-
+    (Used only by Docker Compose) Prefix for container names in the deployment;
+    useful when running multiple deployments on the same machine.
+    This name will be set by default depending on the value of `COMPOSE_PROFILES`, but can be overridden if desired.
+  default: neurobagel_quickstart
+  ini_section: "compose"
+  deployment_profiles:
+    - quickstart
+    - node
+    - portal
+
+- name: NB_ENABLE_AUTH
+  description: >-
+    Whether to enable authentication for cohort queries. One of [`true`, `false`].
+  default: false
+  ini_section: "service:experimental"
+  experimental: true
+  deployment_profiles:  # Do we want to specify these for this variable?
+    - quickstart
+    - node
+    - portal
+
+- name: NB_QUERY_CLIENT_ID
+  description: >-
+    OAuth client ID for the query tool. Required if `NB_ENABLE_AUTH` is set to `true`.
+  default: null
+  ini_section: "service:experimental"
+  experimental: true
+  deployment_profiles:
+    - quickstart
+    - node
+    - portal

--- a/docs/includes/environment_variables.yaml
+++ b/docs/includes/environment_variables.yaml
@@ -41,7 +41,6 @@
   ini_section: "service:graph"
   deployment_profiles:
     - quickstart
-  testing_only: true
 
 - name: NB_GRAPH_MEMORY
   description: >-
@@ -107,7 +106,6 @@
   ini_section: "service:node-api"
   deployment_profiles:
     - quickstart
-  testing_only: true
 
 - name: NB_CONFIG
   description: >-
@@ -161,7 +159,6 @@
   ini_section: "service:federation-api"
   deployment_profiles:
     - quickstart
-  testing_only: true
 
 - name: NB_QUERY_TAG
   description: >-
@@ -181,7 +178,6 @@
   ini_section: "service:query"
   deployment_profiles:
     - quickstart
-  testing_only: true
 
 - name: NB_QUERY_DOMAIN
   description: >-
@@ -207,14 +203,14 @@
   ini_section: "service:query"
   deployment_profiles:
     - quickstart
-  testing_only: true
 
 - name: NB_QUERY_HEADER_SCRIPT
   description: >-
     Custom script to add to the header section of the query tool site, such as for a GDPR-aware analytics tool.
-  default: null
+  default: None
   ini_section: "service:query"
-  developer_only: true  # double check
+  flags:
+    - dev-only
   deployment_profiles:
     - quickstart
     - portal
@@ -222,9 +218,8 @@
 - name: COMPOSE_PROFILES
   description: >-
     Selects the production launch profile to use: `node` or `portal`.
-    If not specified, will default to a testing deployment.
+    If not specified, will default to a test deployment.
     See the [production deployment documentation](https://neurobagel.org/user_guide/production_deployment) for details.
-  default: N/A
   ini_section: "compose"
   deployment_profiles:
     - node
@@ -247,7 +242,8 @@
     Whether to enable authentication for cohort queries. One of [`true`, `false`].
   default: false
   ini_section: "service:experimental"
-  experimental: true
+  flags:
+    - experimental
   deployment_profiles:  # Do we want to specify these for this variable?
     - quickstart
     - node
@@ -256,9 +252,10 @@
 - name: NB_QUERY_CLIENT_ID
   description: >-
     OAuth client ID for the query tool. Required if `NB_ENABLE_AUTH` is set to `true`.
-  default: null
+  default: None
   ini_section: "service:experimental"
-  experimental: true
+  flags:
+    - experimental
   deployment_profiles:
     - quickstart
     - node

--- a/docs/includes/environment_variables.yaml
+++ b/docs/includes/environment_variables.yaml
@@ -9,7 +9,7 @@
 
 - name: NB_GRAPH_SECRETS_PATH
   description: >-
-    Path to files containing the secure passwords to set for the admin user (NB_GRAPH_ADMIN_PASSWORD.txt) and graph database user (NB_GRAPH_PASSWORD.txt).
+    Path to files containing the secure passwords to set for the admin user (`NB_GRAPH_ADMIN_PASSWORD.txt`) and graph database user (`NB_GRAPH_PASSWORD.txt`).
   default: ./secrets
   ini_section: "service:graph"
   deployment_profiles:

--- a/docs/macros/create_environment_variable_reference.py
+++ b/docs/macros/create_environment_variable_reference.py
@@ -1,0 +1,68 @@
+import yaml
+from pathlib import Path
+from typing import Any
+
+
+def define_env(env):
+    flag_admonitions = {
+        "experimental": {"type": "example", "title": "Experimental"},
+        "dev-only": {"type": "warning", "title": "For development environments only"},
+    }
+    data_path = (
+        Path(env.project_dir) / "docs" / "includes" / "environment_variables.yaml"
+    )
+
+    env_vars: list[dict[str, Any]] = yaml.safe_load(
+        data_path.read_text(encoding="utf-8")
+    )
+    vars_by_name = {var["name"]: var for var in env_vars}
+
+    def get_yaml_list(value: Any) -> list:
+        if value is None:
+            return []
+        return value if isinstance(value, list) else [value]
+
+    def as_heading(value: str) -> str:
+        return f"### {value}"
+
+    def as_inline_code(value: Any) -> str:
+        if value == "":
+            return '`""`'
+        return f"`{value}`"
+
+    def as_admonition(admonition_type: str, title: str) -> str:
+        return f'!!! {admonition_type} "{title}"'
+
+    @env.macro
+    def define_env_var(name: str) -> str:
+        """Generate a reference section for a single environment variable as markdown."""
+        var = vars_by_name.get(name)
+
+        var_reference_lines = []
+        var_reference_lines.append(as_heading(var["name"]))
+
+        for flag in get_yaml_list(var.get("flags")):
+            flag_admonition = flag_admonitions.get(flag)
+            if flag_admonition:
+                var_reference_lines.append(
+                    f"{as_admonition(flag_admonition['type'], flag_admonition['title'])}"
+                )
+        if "default" in var:
+            var_reference_lines.append(f"**Default:** {as_inline_code(var['default'])}")
+        var_reference_lines.append(
+            f"**Configuration INI section:** {as_inline_code(var['ini_section'])}"
+        )
+        var_reference_lines.append(
+            f"**Deployment profiles:** {', '.join([as_inline_code(profile) for profile in var['deployment_profiles']])}"
+        )
+        var_reference_lines.append(f"**Description:** {var['description']}")
+
+        return "  \n".join(var_reference_lines)
+
+    @env.macro
+    def define_all_env_vars() -> str:
+        """Generate a reference section for all available environment variables as markdown."""
+        reference_lines = []
+        for var in env_vars:
+            reference_lines.append(define_env_var(var["name"]))
+        return "\n".join(reference_lines)

--- a/docs/macros/main.py
+++ b/docs/macros/main.py
@@ -61,7 +61,7 @@ def define_env(env):
 
     @env.macro
     def create_env_var_reference() -> str:
-        """Generate a reference section for all available environment variables as markdown."""
+        """Generate the full reference markdown for all available environment variables."""
         reference_lines = []
         for var in env_vars:
             reference_lines.append(create_env_reference_section(var["name"]))

--- a/docs/macros/main.py
+++ b/docs/macros/main.py
@@ -2,16 +2,16 @@ import yaml
 from pathlib import Path
 from typing import Any
 
+FLAG_ADMONITIONS = {
+    "experimental": {"type": "example", "title": "Experimental"},
+    "dev-only": {"type": "warning", "title": "For development environments only"},
+}
+
 
 def define_env(env):
-    flag_admonitions = {
-        "experimental": {"type": "example", "title": "Experimental"},
-        "dev-only": {"type": "warning", "title": "For development environments only"},
-    }
     data_path = (
         Path(env.project_dir) / "docs" / "includes" / "environment_variables.yaml"
     )
-
     env_vars: list[dict[str, Any]] = yaml.safe_load(
         data_path.read_text(encoding="utf-8")
     )
@@ -34,7 +34,7 @@ def define_env(env):
         return f'!!! {admonition_type} "{title}"'
 
     @env.macro
-    def define_env_var(name: str) -> str:
+    def create_env_reference_section(name: str) -> str:
         """Generate a reference section for a single environment variable as markdown."""
         var = vars_by_name.get(name)
 
@@ -42,7 +42,7 @@ def define_env(env):
         var_reference_lines.append(as_heading(var["name"]))
 
         for flag in get_yaml_list(var.get("flags")):
-            flag_admonition = flag_admonitions.get(flag)
+            flag_admonition = FLAG_ADMONITIONS.get(flag)
             if flag_admonition:
                 var_reference_lines.append(
                     f"{as_admonition(flag_admonition['type'], flag_admonition['title'])}"
@@ -60,9 +60,9 @@ def define_env(env):
         return "  \n".join(var_reference_lines)
 
     @env.macro
-    def define_all_env_vars() -> str:
+    def create_env_var_reference() -> str:
         """Generate a reference section for all available environment variables as markdown."""
         reference_lines = []
         for var in env_vars:
-            reference_lines.append(define_env_var(var["name"]))
+            reference_lines.append(create_env_reference_section(var["name"]))
         return "\n".join(reference_lines)

--- a/docs/macros/main.py
+++ b/docs/macros/main.py
@@ -1,10 +1,19 @@
 import yaml
 from pathlib import Path
 from typing import Any
+from collections import defaultdict
 
 FLAG_ADMONITIONS = {
     "experimental": {"type": "example", "title": "Experimental"},
     "dev-only": {"type": "warning", "title": "For development environments only"},
+}
+INI_SECTION_MD_HEADINGS = {
+    "service:graph": "Graph store",
+    "service:node-api": "Node API",
+    "service:federation-api": "Federation API",
+    "service:query": "Query tool",
+    "service:experimental": "Experimental settings",
+    "compose": "Docker Compose configuration",
 }
 
 
@@ -16,13 +25,19 @@ def define_env(env):
         data_path.read_text(encoding="utf-8")
     )
     vars_by_name = {var["name"]: var for var in env_vars}
+    vars_by_ini_section = defaultdict(list)
+    for var in env_vars:
+        vars_by_ini_section[var["ini_section"]].append(var)
 
     def get_yaml_list(value: Any) -> list:
         if value is None:
             return []
         return value if isinstance(value, list) else [value]
 
-    def as_heading(value: str) -> str:
+    def as_section_heading(value: str) -> str:
+        return f"## {value}"
+
+    def as_variable_heading(value: str) -> str:
         return f"### {value}"
 
     def as_inline_code(value: Any) -> str:
@@ -39,7 +54,7 @@ def define_env(env):
         var = vars_by_name.get(name)
 
         var_reference_lines = []
-        var_reference_lines.append(as_heading(var["name"]))
+        var_reference_lines.append(as_variable_heading(var["name"]))
 
         for flag in get_yaml_list(var.get("flags")):
             flag_admonition = FLAG_ADMONITIONS.get(flag)
@@ -63,6 +78,11 @@ def define_env(env):
     def create_env_var_reference() -> str:
         """Generate the full reference markdown for all available environment variables."""
         reference_lines = []
-        for var in env_vars:
-            reference_lines.append(create_env_reference_section(var["name"]))
+
+        for ini_section, section_md_heading in INI_SECTION_MD_HEADINGS.items():
+            section_vars = vars_by_ini_section[ini_section]
+            reference_lines.append(as_section_heading(section_md_heading))
+            for var in section_vars:
+                reference_lines.append(create_env_reference_section(var["name"]))
+
         return "\n".join(reference_lines)

--- a/docs/user_guide/.nav.yml
+++ b/docs/user_guide/.nav.yml
@@ -9,6 +9,7 @@ nav:
     - Production deployment: "production_deployment.md"
     - Production deployment with an existing proxy: "production_deployment_with_own_proxy.md"
     - Maintaining a node: "maintaining.md"
+    - Environment variables reference: "environment_variables.md"
   - Annotating your data:
     - Preparing the dataset description: "dataset_description.md"
     - Preparing phenotypic data: "data_prep.md"

--- a/docs/user_guide/environment_variables.md
+++ b/docs/user_guide/environment_variables.md
@@ -1,0 +1,17 @@
+??? warning "Ensure that shell variables do not clash with variables in `.env`"
+    The Neurobagel deployment recipe reads environment variables from a `.env` file
+    generated automatically by the [Neurobagel configuration wizard](production_deployment.md#install-the-neurobagel-configuration-wizard) from your `nb_config.ini` configuration file.
+
+    If the shell you run `docker compose` commands from already has any
+    shell variable of the same name set,
+    the shell variable will take precedence over the `.env`!
+    In this case, make sure to `unset` the local variable(s) first.
+
+    For more information, see [Docker's environment variable precedence](https://docs.docker.com/compose/environment-variables/envvars-precedence/).
+
+!!! tip
+    After running `configure-nb` to configure your deployment, double check that any variables you have customized are resolved with your expected values by running the command `docker compose config` in the directory with the generated `.env`.
+
+Below are all possible configuration variables for a Neurobagel deployment.
+
+{{ define_all_env_vars() }}

--- a/docs/user_guide/environment_variables.md
+++ b/docs/user_guide/environment_variables.md
@@ -13,5 +13,6 @@
     After running `configure-nb` to configure your deployment, double check that any variables you have customized are resolved with your expected values by running the command `docker compose config` in the directory with the generated `.env`.
 
 Below are all possible configuration variables for a Neurobagel deployment.
+Note that `quickstart` indicates whether the variable has an effect in a default test deployment.
 
 {{ define_all_env_vars() }}

--- a/docs/user_guide/environment_variables.md
+++ b/docs/user_guide/environment_variables.md
@@ -15,4 +15,4 @@
 Below are all possible configuration variables for a Neurobagel deployment.
 Note that `quickstart` indicates whether the variable has an effect in a default test deployment.
 
-{{ define_all_env_vars() }}
+{{ create_env_var_reference() }}

--- a/docs/user_guide/getting_started.md
+++ b/docs/user_guide/getting_started.md
@@ -140,7 +140,7 @@ docker compose up -d
 This will:
 
 - pull the required Docker images (if you haven't pulled them before)
-- launch the containers for all [the Neurobagel services](production_deployment.md#services)
+- launch the containers for all the [Neurobagel services](production_deployment.md#deployable-services)
 - automatically set up and configure the services based on your configuration files
 - automatically upload example data to the Neurobagel graph
 

--- a/docs/user_guide/maintaining.md
+++ b/docs/user_guide/maintaining.md
@@ -29,9 +29,13 @@ docker compose pull
     docker image inspect neurobagel/api:latest
     ```
     or, to view only the labels:
+
+    {% raw %}
     ```bash
     docker image inspect --format='{{json .Config.Labels}}' neurobagel/api:latest
     ```
+    {% endraw %}
+
     In either case, you should see something like this in the output:
 
     ```bash

--- a/docs/user_guide/maintaining.md
+++ b/docs/user_guide/maintaining.md
@@ -74,7 +74,7 @@ docker compose up -d
 
 The Neurobagel deployment recipe launches a dedicated graph database that stores the datasets for a single node.
 The data in this graph database is loaded from the path specified in the
-[`LOCAL_GRAPH_DATA` environment variable](#environment-variables-reference),
+[`LOCAL_GRAPH_DATA` environment variable](environment_variables.md#local_graph_data),
 and can be changed at any time.
 
 By default, the graph database will only contain an [example dataset called `BIDS synthetic`](https://github.com/neurobagel/recipes/blob/main/data/example_synthetic_pheno-bids-derivatives.jsonld).
@@ -253,22 +253,3 @@ Some examples of when you might want to do this:
 !!! warning
 
     This action will wipe any graph databases and users you previously created!
-
-## Environment variables reference
-
-??? warning "Ensure that shell variables do not clash with `.env` file"
-
-    If the shell you run `docker compose` from already has any
-    shell variable of the same name set,
-    the shell variable will take precedence over the configuration
-    of `.env`!
-    In this case, make sure to `unset` the local variable first.
-
-    For more information, see [Docker's environment variable precedence](https://docs.docker.com/compose/environment-variables/envvars-precedence/).
-
-!!! tip
-    Double check that any environment variables you have customized in `.env` are resolved with your expected values using the command `docker compose config`.
-
-Below are all the possible Neurobagel environment variables that can be set in `.env`.
-
-{{ read_table('./repos/recipes/docs/neurobagel_environment_variables.tsv') }}

--- a/docs/user_guide/production_deployment.md
+++ b/docs/user_guide/production_deployment.md
@@ -205,7 +205,7 @@ NB_NAPI_BASE_PATH=/node
 
 !!! info
     For more details on all available environment variables,
-    see the [Environment variable reference](maintaining.md#environment-variables-reference).
+    see the [Environment variable reference](environment_variables.md).
 
 The following sections describe the node configuration options in more detail.
 
@@ -413,7 +413,7 @@ NB_QUERY_APP_BASE_PATH=/
 
 !!! info
     For more details on all available environment variables,
-    see the [Environment variable reference](maintaining.md#environment-variables-reference).
+    see the [Environment variable reference](environment_variables.md).
 
 The following sections describe the portal configuration options in more detail.
 
@@ -462,7 +462,7 @@ For simplicity, we recommend using numeric IDs such as `[node:1]`, `[node:2]`, e
     By default, every new f-API will look up this list
     on startup and include it in its internal list of nodes to
     federate over
-    (this can be disabled by setting the variable [`NB_FEDERATE_REMOTE_PUBLIC_NODES`](maintaining.md#environment-variables-reference) in `nb_config.ini`).
+    (this can be disabled by setting the variable [`NB_FEDERATE_REMOTE_PUBLIC_NODES`](environment_variables.md#nb_federate_remote_public_nodes) in `nb_config.ini`).
     This means that you do not have to manually define these public nodes in `nb_config.ini`.
 
 !!! danger "Do not include URLs of federation APIs as `API_URL`"

--- a/docs/user_guide/production_deployment_with_own_proxy.md
+++ b/docs/user_guide/production_deployment_with_own_proxy.md
@@ -47,7 +47,7 @@ Begin by following the default setup instructions for your
 
 Neurobagel node services run inside Docker containers. Each service listens on an *internal port* within its container and
 exposes a *host port* that makes it accessible from the host machine. Below, we list the default *host ports* for each service
-along with the [environment variables](maintaining.md#environment-variables-reference) that can be used to configure them.
+along with the [environment variables](environment_variables.md) that can be used to configure them.
 
 - `api` (the node API)
     - environment variable: `NB_NAPI_PORT_HOST`

--- a/docs/user_guide/query_tool.md
+++ b/docs/user_guide/query_tool.md
@@ -26,7 +26,7 @@ Harmonized data are provided as standardized vocabulary-derived labels for reada
 Each row corresponds to a single matching subject session, except for [datasets configured to only return aggregate results](#protected-subject-level-results-for-aggregate-datasets).
 
 ??? abstract "Example query result TSV"
-    {{ read_table('./repos/neurobagel_examples/query-tool-results/neurobagel-query-results_YYYYMMDDHHMMSS.tsv') }}
+    {{ read_table('./repos/neurobagel_examples/query-tool-results/neurobagel-query-results_YYYYMMDDHHMMSS.tsv') | add_indentation(spaces=4) }}
 
 Columns in the TSV are described below:
 `*` = required values
@@ -59,7 +59,7 @@ A machine-optimized version of the query results, containing [URIs](https://www.
 Each row corresponds to a single matching subject session, except for [datasets configured to only return aggregate results](#protected-subject-level-results-for-aggregate-datasets).
 
 ??? abstract "Example query result TSV"
-    {{ read_table('./repos/neurobagel_examples/query-tool-results/neurobagel-query-results-with-URIs_YYYYMMDDHHMMSS.tsv') }}
+    {{ read_table('./repos/neurobagel_examples/query-tool-results/neurobagel-query-results-with-URIs_YYYYMMDDHHMMSS.tsv') | add_indentation(spaces=4) }}
 
 This file contains the same columns and data as the [descriptive query results TSV](#harmonized-tsv-data-with-descriptive-labels).
 However, the harmonized terms in the following columns are provided in their raw URI form instead of as descriptive labels:

--- a/docs/user_guide/query_tool.md
+++ b/docs/user_guide/query_tool.md
@@ -82,7 +82,7 @@ However, the harmonized terms in the following columns are provided in their raw
 
 A row in a query result TSV may show `protected` for all columns except for `DatasetName`, `RepositoryURL`, `AccessLink` and other dataset-level columns. This means the source graph database (node) has been configured (via its corresponding Neurobagel node API) to return only aggregate information about matching subjects e.g., for data privacy reasons.
 
-More information on this configuration setting, called `NB_RETURN_AGG`, and how to change it for a node can be found [here](maintaining.md#environment-variables-reference).
+This setting for a node can be changed using the environment variable [`NB_RETURN_AGG`](environment_variables.md#nb_return_agg).
 
 ## Testing
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,8 @@ markdown_extensions:
 
 plugins:
   - search
+  - macros:
+      module_name: docs/macros/main
   - table-reader
   - yamp:
     # directory within docs dir to add content

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,15 +74,12 @@ plugins:
       #   default: []
       repos:
         # the git repository URL to clone
-      - url: "https://github.com/neurobagel/recipes"
+      - url: "https://github.com/neurobagel/neurobagel_examples"
         # a list of globs to checkout
         # if empty or not provided, the entire repository is cloned
         # default: [ ]
-        include: [ "docs/neurobagel_environment_variables.tsv"]
-        # the branch of the repository to clone
-        branch: "main"
-      - url: "https://github.com/neurobagel/neurobagel_examples"
         include: [ "query-tool-results" ]
+        # the branch of the repository to clone
         branch: "main"
   - include-markdown
   - open-in-new-tab

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 mkdocs-awesome-nav
 mkdocs-include-markdown-plugin[cache]
+mkdocs-macros-plugin
 mkdocs-madlibs
 mkdocs-material>=9.5.0
 mkdocs-open-in-new-tab
@@ -8,3 +9,4 @@ mkdocs-table-reader-plugin>=3.0.0
 mkdocs-yamp
 pre-commit
 pymdown-extensions>=10.12
+pyyaml


### PR DESCRIPTION
<!--
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #337 

<!--
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- define all environment variables in a YAML file
  - note: we can probably eventually auto-generate this YAML from the [models](https://github.com/neurobagel/configure-nb/blob/main/configure_nb/models.py) in `configure-nb` directly and just include it as an external file in this repo
- use [mkdocs-macros](https://mkdocs-macros-plugin.readthedocs.io/en/latest/) to render environment variable YAML as markdown sections with one heading per variable
- move environment variable reference to standalone docs page
- update existing links to environment variable reference

<!-- To be checked off by reviewers -->
## Checklist
_Please leave checkboxes empty for PR reviewers_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`) _see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING/#pull-request-guidelines) for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Checks pass
- [ ] If an existing page was renamed or deleted, redirects have been added to [the `mkdocs.yml` config](https://github.com/neurobagel/documentation/blob/main/mkdocs.yml)
