### PR TITLE
[MNT] Ignore false-positive URL & remove duplicate pattern from markdown-link-check

### DIFF
--- a/md_link_check_config.json
+++ b/md_link_check_config.json
@@ -2,7 +2,6 @@
   "ignorePatterns": [
     { "pattern": "http://neurobagel.org/vocab/.*" },
     { "pattern": "http://neurobagel.org/graph/" },
-    { "pattern": "http://neurobagel.org/graph/" },
     { "pattern": ".*localhost.*" },
     { "pattern": "https://api.neurobagel.org/.*" },
     { "pattern": "http://purl.org/nidash/nidm#.*" },
@@ -12,6 +11,7 @@
     { "pattern": "https://www.ontotext.com/knowledgehub/fundamentals/" },
     { "pattern": "overrides/assets/img/" },
     { "pattern": "https://www.w3.org/RDF/" }
+    { "pattern": "https://en.wikipedia.org/wiki/CURIE" }
   ],
   "timeout": "120s",
   "aliveStatusCodes": [429, 200, 202, 403, 405],

--- a/md_link_check_config.json
+++ b/md_link_check_config.json
@@ -10,7 +10,7 @@
     { "pattern": "http://purl.bioontology.org/ontology/SNOMEDCT/" },
     { "pattern": "https://www.ontotext.com/knowledgehub/fundamentals/" },
     { "pattern": "overrides/assets/img/" },
-    { "pattern": "https://www.w3.org/RDF/" }
+    { "pattern": "https://www.w3.org/RDF/" },
     { "pattern": "https://en.wikipedia.org/wiki/CURIE" }
   ],
   "timeout": "120s",


### PR DESCRIPTION
<!--
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- See failing pre-commit check at https://github.com/neurobagel/documentation/actions/runs/33398347158/job/100781469539

<!--
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Remove URL that is causing a false-positive 404 error for `markdown-link-check` (navigating to the URL in the browser or via curl request both work without issue)

<!-- To be checked off by reviewers -->
## Checklist

_Please leave checkboxes empty for PR reviewers_

- [x] PR has an interpretable title with a prefix
      (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`)
      _see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING/#pull-request-guidelines) for more info_
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Checks pass
- [ ] If an existing page was renamed or deleted, redirects have been added to [the `mkdocs.yml` config](https://github.com/neurobagel/documentation/blob/main/mkdocs.yml)
